### PR TITLE
feat: GitHub Copilot CLI を sandbox に統合

### DIFF
--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -25,7 +25,8 @@
   - Copilot CLI の非対話経路では `docker compose exec -T` を使い、Compose 既定の TTY 割り当てを無効化する
   - `-p` / `--prompt` を使う programmatic 実行は、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` または `COPILOT_ALLOW_ALL` による承認オーバーライドがある場合にのみ非対話経路へ流す
   - 対話モードの `copilot` / `copilot --interactive` は TTY 前提のまま扱い、stdin または stdout が非 TTY の場合は非対話経路へ暗黙変換せず明示エラーにする
-  - `copilot help [topic]`、`version`、`-v/--version`、stdin からオプション列を受ける headless invocation は tmux を使わず直接実行できる
+  - `copilot help [topic]`、`version`、`-v/--version`、`init`、`update`、`plugin ...`、`login`、`logout`、stdin からオプション列を受ける headless invocation は tmux を使わず直接実行できる
+  - Copilot の tmux セッション名はワークスペースごとに衝突しない
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
   - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
@@ -81,10 +82,10 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. `-p` / `--prompt`、`help`、`version`、`-v/--version`、または stdin 非 TTYかつ引数空のケースを headless invocation とみなす
+  2. `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、または stdin 非 TTYかつ引数空のケースを headless invocation とみなす
   3. `-p` / `--prompt` を含む headless invocation では、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` を検査する
   4. `-p` / `--prompt` で承認オーバーライドが揃っている場合のみ tmux をバイパスして `docker compose exec -T` の直接実行へ進む
-  5. `help` / `version` / stdin オプション入力の headless invocation は、承認オーバーライド不要で直接実行へ進む
+  5. `help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / stdin オプション入力の headless invocation は、承認オーバーライド不要で直接実行へ進む
   6. `-p` / `--prompt` で承認オーバーライドが無い場合は、必要なフラグまたは環境変数を案内して明示エラーにする
   7. headless invocation でない場合は対話モードとして扱い、`stdin` と `stdout` の両方が TTY のときだけ tmux セッションを生成または再利用する
   8. 対話モードで `stdin` または `stdout` のどちらかが非 TTY の場合は、非対話経路へ暗黙変換せず明示エラーにする
@@ -123,7 +124,7 @@
   - Errors/Exceptions: なし
 - IF-010: `host/sandbox::copilot_requests_headless_mode([copilot_args...])`
   - Input: `copilot` へ渡す引数配列と stdin の TTY 状態
-  - Output: `-p` / `--prompt`、`help`、`version`、`-v/--version`、stdin オプション入力など、tmux を使わず直接実行すべき headless invocation かを判定する
+  - Output: `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、stdin オプション入力など、tmux を使わず直接実行すべき headless invocation かを判定する
   - Errors/Exceptions: なし
 - IF-008: `host/sandbox::copilot_has_approval_override([copilot_args...])`
   - Input: `copilot` へ渡す引数配列と `COPILOT_ALLOW_ALL`
@@ -139,7 +140,7 @@
   - Errors/Exceptions: なし
 - IF-003: `host/sandbox::compute_copilot_session_name()`
   - Input: `CALLER_PWD`
-  - Output: `<sanitized-base>-copilot-sandbox`
+  - Output: `<sanitized-base>-<hash12>-copilot-sandbox`
   - Errors/Exceptions: なし
 - IF-004: `host/sandbox::print_help_copilot()`
   - Input: なし
@@ -157,8 +158,9 @@
   - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
   - `host/sandbox`: Copilot の非対話時は `docker compose exec -T` を使うよう修正し、stdout リダイレクト時も tmux をバイパスする
   - `host/sandbox`: Copilot の対話/非対話モードを明示判定し、対話モードで TTY が足りない場合は明示エラー、`-p` / `--prompt` では承認オーバーライドを必須化する
-  - `host/sandbox`: Copilot の headless invocation を `-p` / `--prompt` 以外にも拡張し、`help` / `version` / stdin オプション入力を tmux なしで直接実行できるようにする
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド別名、help/version の direct exec、stdin オプション入力、TTY 不足時の明示エラー、終了コード保持のテストを追加・更新する
+  - `host/sandbox`: Copilot の headless invocation を `-p` / `--prompt` 以外にも拡張し、`help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / stdin オプション入力を tmux なしで直接実行できるようにする
+  - `host/sandbox`: Copilot の tmux セッション名をフルパス由来のハッシュ付きに変更し、basename 衝突を避ける
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド別名、公式 headless サブコマンド、help/version の direct exec、stdin オプション入力、TTY 不足時の明示エラー、セッション名一意性、終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -188,12 +190,14 @@
     - `.agent-home/.copilot` が作成されること
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
     - `sandbox copilot -- --help` と `sandbox copilot -- --version` が direct exec として pass-through されること
+    - `sandbox copilot -- init` や `sandbox copilot -- plugin ...` などの公式サブコマンドが direct exec として pass-through されること
     - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
     - stdin からオプション列を受ける `copilot` 実行が tmux を使わないこと
     - stdout リダイレクト付きの対話モードは明示エラーになること
     - 非対話実行では `docker compose exec -T` が使われること
     - 非対話実行時に Copilot の失敗終了コードが保持されること
     - `-p` / `--prompt` 実行では `--allow-all-tools` / `--allow-tool` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` が承認オーバーライドとして認識されること
+    - 別ワークスペースでも tmux セッション名が衝突しないこと
     - tmux 未導入時にエラー終了すること
   - Frontend: なし
 - どのAC/ECをどのテストで保証するか:
@@ -201,7 +205,7 @@
     - `package.json` の `install-global` に `@github/copilot` が入ること
     - `package.json` の `verify` に `copilot --version` が入ること
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
-  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`
+  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_session_name_disambiguates_same_basename_paths`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`, `copilot_init_uses_direct_exec`
   - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`, `copilot_programmatic_requires_approval_override`, `copilot_programmatic_accepts_allow_all_aliases`, `copilot_stdin_option_stream_uses_direct_exec`
   - AC-003 → 新規 `copilot_redirected_stdout_errors_for_interactive_mode`
   - AC-004 → 新規 `help_copilot_mentions_tmux`

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -20,6 +20,8 @@
   - Dockerfile、docker-compose、`host/sandbox`、`package.json`、テストを連動して更新する
   - Copilot CLI の標準ディレクトリを使う
   - `sandbox copilot [options] -- [copilot args...]` の契約を明示し、`--` より後ろは `copilot` へ pass-through する
+  - Copilot CLI の非対話・programmatic 利用では tmux を自動バイパスし、標準入出力を親プロセスへ返す
+  - `sandbox copilot` は Copilot CLI の終了コードを失わずに呼び出し元へ返す
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
   - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
@@ -73,10 +75,12 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. セッションが無ければ `SANDBOX_COPILOT_NO_TMUX=1 sandbox copilot ...` を新規セッション内で起動する
-  3. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
-  4. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
-  5. `docker compose exec -w <container_workdir> agent-sandbox /bin/zsh -lc 'copilot "$@"; exec /bin/zsh' -- ...` を実行する
+  2. 標準入出力が TTY であり、かつ programmatic mode を要求する引数が無い場合のみ tmux セッションを生成または再利用する
+  3. 標準入出力が非 TTY、または Copilot の programmatic mode を要求する場合は tmux をバイパスして直接コンテナ実行へ進む
+  4. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
+  5. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
+  6. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
+  7. 非対話実行では `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
 - Flow for AC-004:
   1. help 表示時は `copilot` サブコマンドを認識する
   2. ただちに help テキストだけを返し、副作用を起こさない
@@ -96,12 +100,20 @@
   - Errors/Exceptions: 作成不能時は `mkdir -p` 失敗で終了
 - IF-002: `host/sandbox::run_compose_exec_copilot(container_workdir, container_name, compose_project_name, abs_mount_root, [copilot_args...])`
   - Input: container workdir と compose 実行文脈、任意の Copilot 引数
-  - Output: コンテナ内で `copilot` を実行し、終了後 zsh に戻る
-  - Errors/Exceptions: compose exec 失敗時はその終了コードを返す
+  - Output: コンテナ内で `copilot` を実行し、対話実行では成功時のみ zsh に戻る
+  - Errors/Exceptions: Copilot または compose exec の終了コードをそのまま返す
 - IF-005: `host/sandbox::split_copilot_args()`
   - Input: `sandbox copilot` に渡された全引数
   - Output: sandbox 側引数と `--` 以降の `copilot` 側引数を分離する
   - Errors/Exceptions: `--` が無い場合は Copilot 引数を空配列として扱う
+- IF-006: `host/sandbox::copilot_requests_programmatic_mode([copilot_args...])`
+  - Input: `copilot` へ渡す引数配列
+  - Output: `-p` / `--prompt` / `-s` / `--silent` など、programmatic 利用を示すフラグの有無を判定する
+  - Errors/Exceptions: なし
+- IF-007: `host/sandbox::copilot_should_use_tmux([copilot_args...])`
+  - Input: 現在の stdin/stdout の TTY 状態と `copilot` 引数
+  - Output: 対話実行なら 0、非対話/自動化実行なら非 0
+  - Errors/Exceptions: なし
 - IF-003: `host/sandbox::compute_copilot_session_name()`
   - Input: `CALLER_PWD`
   - Output: `<sanitized-base>-copilot-sandbox`
@@ -119,7 +131,8 @@
   - `Dockerfile`: `/home/node/.copilot` の事前作成と所有権設定を追加する
   - `docker-compose.yml`: `.agent-home/.copilot:/home/node/.copilot` mount を追加し、Copilot 用の追加 XDG/config/cache mount は設けない
   - `host/sandbox`: `.agent-home` 初期化、help、subcommand 判定、引数分離、tmux/compose ベースの `sandbox copilot [options] -- [copilot args...]` 実装を追加する
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストを追加・更新する
+  - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパスと終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -133,6 +146,7 @@
 - AC-002 → `host/sandbox::ensure_agent_home_dirs`, `Dockerfile`, `docker-compose.yml`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::run_compose_exec_copilot`, `host/sandbox::compute_copilot_session_name`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::split_copilot_args`
+- AC-003 → `host/sandbox::copilot_requests_programmatic_mode`, `host/sandbox::copilot_should_use_tmux`
 - AC-004 → `host/sandbox::print_help`, `host/sandbox::print_help_tools`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - EC-001 → `host/sandbox::ensure_tmux_available`, `tests/sandbox_cli.test.sh`
 - EC-002 → help 判定ロジック、`tests/sandbox_cli.test.sh`
@@ -148,6 +162,8 @@
     - `.agent-home/.copilot` が作成されること
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
     - `sandbox copilot -- --help` が `copilot --help` として pass-through されること
+    - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
+    - 非対話実行時に Copilot の失敗終了コードが保持されること
     - tmux 未導入時にエラー終了すること
   - Frontend: なし
 - どのAC/ECをどのテストで保証するか:
@@ -156,6 +172,7 @@
     - `package.json` の `verify` に `copilot --version` が入ること
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
   - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`
+  - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
   - AC-004 → 新規 `help_copilot_mentions_tmux`
   - EC-001 → 新規 `copilot_errors_when_tmux_missing`
   - EC-002 → `help` 系テスト

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -23,10 +23,14 @@
   - Copilot CLI の非対話・programmatic 利用では tmux を自動バイパスし、標準入出力を親プロセスへ返す
   - `sandbox copilot` は Copilot CLI の終了コードを失わずに呼び出し元へ返す
   - Copilot CLI の非対話経路では `docker compose exec -T` を使い、Compose 既定の TTY 割り当てを無効化する
+  - `-p` / `--prompt` を使う programmatic 実行は、`--allow-all-tools` / `--allow-tool ...` または `COPILOT_ALLOW_ALL` による承認オーバーライドがある場合にのみ非対話経路へ流す
+  - 対話モードの `copilot` / `copilot --interactive` は TTY 前提のまま扱い、stdin または stdout が非 TTY の場合は非対話経路へ暗黙変換せず明示エラーにする
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
   - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
   - Copilot 独自の認証/権限制御をラッパーに実装しない
+  - 承認オーバーライドが無い `-p` / `--prompt` 実行を「対応済みの非対話フロー」として扱わない
+  - 対話モードを stdout リダイレクトやコマンド置換だけを理由に自動で `exec -T` 経路へ落とさない
 - 非交渉制約:
   - 既存 `.agent-home` 設計と deterministic な stub テストを維持する
   - 既存 CLI の挙動を壊さない
@@ -76,12 +80,15 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. `stdin` と `stdout` の両方が TTY であり、かつ programmatic mode を要求する引数が無い場合のみ tmux セッションを生成または再利用する
-  3. `stdin` または `stdout` のどちらかが非 TTY、または Copilot の programmatic mode を要求する場合は tmux をバイパスして直接コンテナ実行へ進む
-  4. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
-  5. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
-  6. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
-  7. 非対話実行では `docker compose exec -T` で `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
+  2. `-p` / `--prompt` が指定されている場合は programmatic mode とみなし、`--allow-all-tools` / `--allow-tool ...` / `COPILOT_ALLOW_ALL` を検査する
+  3. programmatic mode で承認オーバーライドが揃っている場合のみ tmux をバイパスして `docker compose exec -T` の直接実行へ進む
+  4. programmatic mode で承認オーバーライドが無い場合は、必要なフラグまたは環境変数を案内して明示エラーにする
+  5. programmatic mode でない場合は対話モードとして扱い、`stdin` と `stdout` の両方が TTY のときだけ tmux セッションを生成または再利用する
+  6. 対話モードで `stdin` または `stdout` のどちらかが非 TTY の場合は、非対話経路へ暗黙変換せず明示エラーにする
+  7. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
+  8. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
+  9. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
+  10. 非対話実行では `docker compose exec -T` で `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
 - Flow for AC-004:
   1. help 表示時は `copilot` サブコマンドを認識する
   2. ただちに help テキストだけを返し、副作用を起こさない
@@ -109,11 +116,19 @@
   - Errors/Exceptions: `--` が無い場合は Copilot 引数を空配列として扱う
 - IF-006: `host/sandbox::copilot_requests_programmatic_mode([copilot_args...])`
   - Input: `copilot` へ渡す引数配列
-  - Output: `-p` / `--prompt` / `-s` / `--silent` など、programmatic 利用を示すフラグの有無を判定する
+  - Output: `-p` / `--prompt` など、programmatic 利用を示すフラグの有無を判定する
   - Errors/Exceptions: なし
+- IF-008: `host/sandbox::copilot_has_approval_override([copilot_args...])`
+  - Input: `copilot` へ渡す引数配列と `COPILOT_ALLOW_ALL`
+  - Output: `--allow-all-tools`、`--allow-tool ...`、`COPILOT_ALLOW_ALL` のいずれかで非対話実行に必要な承認オーバーライドが存在するかを判定する
+  - Errors/Exceptions: なし
+- IF-009: `host/sandbox::validate_copilot_invocation([copilot_args...])`
+  - Input: 現在の stdin/stdout の TTY 状態、`copilot` 引数、`COPILOT_ALLOW_ALL`
+  - Output: 呼び出しが対話モードとして成立するか、または programmatic mode の前提を満たしているかを検証する
+  - Errors/Exceptions: 前提不足時は stderr に補正方法を出して非 0 を返す
 - IF-007: `host/sandbox::copilot_should_use_tmux([copilot_args...])`
   - Input: 現在の stdin/stdout の TTY 状態と `copilot` 引数
-  - Output: 対話実行なら 0、非対話/自動化実行なら非 0
+  - Output: 妥当な対話実行なら 0、programmatic 実行または tmux 不使用なら非 0
   - Errors/Exceptions: なし
 - IF-003: `host/sandbox::compute_copilot_session_name()`
   - Input: `CALLER_PWD`
@@ -134,7 +149,8 @@
   - `host/sandbox`: `.agent-home` 初期化、help、subcommand 判定、引数分離、tmux/compose ベースの `sandbox copilot [options] -- [copilot args...]` 実装を追加する
   - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
   - `host/sandbox`: Copilot の非対話時は `docker compose exec -T` を使うよう修正し、stdout リダイレクト時も tmux をバイパスする
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、stdout リダイレクト時バイパス、終了コード保持のテストを追加・更新する
+  - `host/sandbox`: Copilot の対話/非対話モードを明示判定し、対話モードで TTY が足りない場合は明示エラー、`-p` / `--prompt` では承認オーバーライドを必須化する
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド必須、TTY 不足時の明示エラー、終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -148,7 +164,7 @@
 - AC-002 → `host/sandbox::ensure_agent_home_dirs`, `Dockerfile`, `docker-compose.yml`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::run_compose_exec_copilot`, `host/sandbox::compute_copilot_session_name`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::split_copilot_args`
-- AC-003 → `host/sandbox::copilot_requests_programmatic_mode`, `host/sandbox::copilot_should_use_tmux`
+- AC-003 → `host/sandbox::copilot_requests_programmatic_mode`, `host/sandbox::copilot_has_approval_override`, `host/sandbox::validate_copilot_invocation`, `host/sandbox::copilot_should_use_tmux`
 - AC-004 → `host/sandbox::print_help`, `host/sandbox::print_help_tools`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - EC-001 → `host/sandbox::ensure_tmux_available`, `tests/sandbox_cli.test.sh`
 - EC-002 → help 判定ロジック、`tests/sandbox_cli.test.sh`
@@ -165,9 +181,10 @@
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
     - `sandbox copilot -- --help` が `copilot --help` として pass-through されること
     - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
-    - stdout リダイレクトやコマンド置換でも tmux を使わないこと
+    - stdout リダイレクト付きの対話モードは明示エラーになること
     - 非対話実行では `docker compose exec -T` が使われること
     - 非対話実行時に Copilot の失敗終了コードが保持されること
+    - `-p` / `--prompt` 実行では承認オーバーライドが必須であること
     - tmux 未導入時にエラー終了すること
   - Frontend: なし
 - どのAC/ECをどのテストで保証するか:
@@ -176,8 +193,8 @@
     - `package.json` の `verify` に `copilot --version` が入ること
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
   - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`
-  - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
-  - AC-003 → 新規 `copilot_redirected_stdout_bypasses_tmux`
+  - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`, `copilot_programmatic_requires_approval_override`
+  - AC-003 → 新規 `copilot_redirected_stdout_errors_for_interactive_mode`
   - AC-004 → 新規 `help_copilot_mentions_tmux`
   - EC-001 → 新規 `copilot_errors_when_tmux_missing`
   - EC-002 → `help` 系テスト

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -23,8 +23,9 @@
   - Copilot CLI の非対話・programmatic 利用では tmux を自動バイパスし、標準入出力を親プロセスへ返す
   - `sandbox copilot` は Copilot CLI の終了コードを失わずに呼び出し元へ返す
   - Copilot CLI の非対話経路では `docker compose exec -T` を使い、Compose 既定の TTY 割り当てを無効化する
-  - `-p` / `--prompt` を使う programmatic 実行は、`--allow-all-tools` / `--allow-tool ...` または `COPILOT_ALLOW_ALL` による承認オーバーライドがある場合にのみ非対話経路へ流す
+  - `-p` / `--prompt` を使う programmatic 実行は、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` または `COPILOT_ALLOW_ALL` による承認オーバーライドがある場合にのみ非対話経路へ流す
   - 対話モードの `copilot` / `copilot --interactive` は TTY 前提のまま扱い、stdin または stdout が非 TTY の場合は非対話経路へ暗黙変換せず明示エラーにする
+  - `copilot help [topic]`、`version`、`-v/--version`、stdin からオプション列を受ける headless invocation は tmux を使わず直接実行できる
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
   - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
@@ -80,15 +81,17 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. `-p` / `--prompt` が指定されている場合は programmatic mode とみなし、`--allow-all-tools` / `--allow-tool ...` / `COPILOT_ALLOW_ALL` を検査する
-  3. programmatic mode で承認オーバーライドが揃っている場合のみ tmux をバイパスして `docker compose exec -T` の直接実行へ進む
-  4. programmatic mode で承認オーバーライドが無い場合は、必要なフラグまたは環境変数を案内して明示エラーにする
-  5. programmatic mode でない場合は対話モードとして扱い、`stdin` と `stdout` の両方が TTY のときだけ tmux セッションを生成または再利用する
-  6. 対話モードで `stdin` または `stdout` のどちらかが非 TTY の場合は、非対話経路へ暗黙変換せず明示エラーにする
-  7. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
-  8. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
-  9. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
-  10. 非対話実行では `docker compose exec -T` で `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
+  2. `-p` / `--prompt`、`help`、`version`、`-v/--version`、または stdin 非 TTYかつ引数空のケースを headless invocation とみなす
+  3. `-p` / `--prompt` を含む headless invocation では、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` を検査する
+  4. `-p` / `--prompt` で承認オーバーライドが揃っている場合のみ tmux をバイパスして `docker compose exec -T` の直接実行へ進む
+  5. `help` / `version` / stdin オプション入力の headless invocation は、承認オーバーライド不要で直接実行へ進む
+  6. `-p` / `--prompt` で承認オーバーライドが無い場合は、必要なフラグまたは環境変数を案内して明示エラーにする
+  7. headless invocation でない場合は対話モードとして扱い、`stdin` と `stdout` の両方が TTY のときだけ tmux セッションを生成または再利用する
+  8. 対話モードで `stdin` または `stdout` のどちらかが非 TTY の場合は、非対話経路へ暗黙変換せず明示エラーにする
+  9. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
+  10. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
+  11. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
+  12. 非対話実行では `docker compose exec -T` で `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
 - Flow for AC-004:
   1. help 表示時は `copilot` サブコマンドを認識する
   2. ただちに help テキストだけを返し、副作用を起こさない
@@ -118,17 +121,21 @@
   - Input: `copilot` へ渡す引数配列
   - Output: `-p` / `--prompt` など、programmatic 利用を示すフラグの有無を判定する
   - Errors/Exceptions: なし
+- IF-010: `host/sandbox::copilot_requests_headless_mode([copilot_args...])`
+  - Input: `copilot` へ渡す引数配列と stdin の TTY 状態
+  - Output: `-p` / `--prompt`、`help`、`version`、`-v/--version`、stdin オプション入力など、tmux を使わず直接実行すべき headless invocation かを判定する
+  - Errors/Exceptions: なし
 - IF-008: `host/sandbox::copilot_has_approval_override([copilot_args...])`
   - Input: `copilot` へ渡す引数配列と `COPILOT_ALLOW_ALL`
-  - Output: `--allow-all-tools`、`--allow-tool ...`、`COPILOT_ALLOW_ALL` のいずれかで非対話実行に必要な承認オーバーライドが存在するかを判定する
+  - Output: `--allow-all-tools`、`--allow-tool ...`、`--allow-all`、`--yolo`、`COPILOT_ALLOW_ALL` のいずれかで非対話実行に必要な承認オーバーライドが存在するかを判定する
   - Errors/Exceptions: なし
 - IF-009: `host/sandbox::validate_copilot_invocation([copilot_args...])`
   - Input: 現在の stdin/stdout の TTY 状態、`copilot` 引数、`COPILOT_ALLOW_ALL`
-  - Output: 呼び出しが対話モードとして成立するか、または programmatic mode の前提を満たしているかを検証する
+  - Output: 呼び出しが対話モードとして成立するか、または headless invocation の前提を満たしているかを検証する
   - Errors/Exceptions: 前提不足時は stderr に補正方法を出して非 0 を返す
 - IF-007: `host/sandbox::copilot_should_use_tmux([copilot_args...])`
   - Input: 現在の stdin/stdout の TTY 状態と `copilot` 引数
-  - Output: 妥当な対話実行なら 0、programmatic 実行または tmux 不使用なら非 0
+  - Output: 妥当な対話実行なら 0、headless invocation または tmux 不使用なら非 0
   - Errors/Exceptions: なし
 - IF-003: `host/sandbox::compute_copilot_session_name()`
   - Input: `CALLER_PWD`
@@ -150,7 +157,8 @@
   - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
   - `host/sandbox`: Copilot の非対話時は `docker compose exec -T` を使うよう修正し、stdout リダイレクト時も tmux をバイパスする
   - `host/sandbox`: Copilot の対話/非対話モードを明示判定し、対話モードで TTY が足りない場合は明示エラー、`-p` / `--prompt` では承認オーバーライドを必須化する
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド必須、TTY 不足時の明示エラー、終了コード保持のテストを追加・更新する
+  - `host/sandbox`: Copilot の headless invocation を `-p` / `--prompt` 以外にも拡張し、`help` / `version` / stdin オプション入力を tmux なしで直接実行できるようにする
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド別名、help/version の direct exec、stdin オプション入力、TTY 不足時の明示エラー、終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -164,7 +172,7 @@
 - AC-002 → `host/sandbox::ensure_agent_home_dirs`, `Dockerfile`, `docker-compose.yml`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::run_compose_exec_copilot`, `host/sandbox::compute_copilot_session_name`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - AC-003 → `host/sandbox::split_copilot_args`
-- AC-003 → `host/sandbox::copilot_requests_programmatic_mode`, `host/sandbox::copilot_has_approval_override`, `host/sandbox::validate_copilot_invocation`, `host/sandbox::copilot_should_use_tmux`
+- AC-003 → `host/sandbox::copilot_requests_programmatic_mode`, `host/sandbox::copilot_requests_headless_mode`, `host/sandbox::copilot_has_approval_override`, `host/sandbox::validate_copilot_invocation`, `host/sandbox::copilot_should_use_tmux`
 - AC-004 → `host/sandbox::print_help`, `host/sandbox::print_help_tools`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
 - EC-001 → `host/sandbox::ensure_tmux_available`, `tests/sandbox_cli.test.sh`
 - EC-002 → help 判定ロジック、`tests/sandbox_cli.test.sh`
@@ -179,12 +187,13 @@
     - `help` に Copilot が反映されること
     - `.agent-home/.copilot` が作成されること
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
-    - `sandbox copilot -- --help` が `copilot --help` として pass-through されること
+    - `sandbox copilot -- --help` と `sandbox copilot -- --version` が direct exec として pass-through されること
     - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
+    - stdin からオプション列を受ける `copilot` 実行が tmux を使わないこと
     - stdout リダイレクト付きの対話モードは明示エラーになること
     - 非対話実行では `docker compose exec -T` が使われること
     - 非対話実行時に Copilot の失敗終了コードが保持されること
-    - `-p` / `--prompt` 実行では承認オーバーライドが必須であること
+    - `-p` / `--prompt` 実行では `--allow-all-tools` / `--allow-tool` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` が承認オーバーライドとして認識されること
     - tmux 未導入時にエラー終了すること
   - Frontend: なし
 - どのAC/ECをどのテストで保証するか:
@@ -192,8 +201,8 @@
     - `package.json` の `install-global` に `@github/copilot` が入ること
     - `package.json` の `verify` に `copilot --version` が入ること
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
-  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`
-  - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`, `copilot_programmatic_requires_approval_override`
+  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`
+  - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`, `copilot_programmatic_requires_approval_override`, `copilot_programmatic_accepts_allow_all_aliases`, `copilot_stdin_option_stream_uses_direct_exec`
   - AC-003 → 新規 `copilot_redirected_stdout_errors_for_interactive_mode`
   - AC-004 → 新規 `help_copilot_mentions_tmux`
   - EC-001 → 新規 `copilot_errors_when_tmux_missing`

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -1,253 +1,208 @@
 ---
 種別: 設計書
-機能ID: "<FEATURE_ID>"
-機能名: "<FEATURE_NAME>"
-関連Issue: ["<ISSUE_NUMBER_OR_URL>"]
-状態: "draft | approved"
-作成者: "<YOUR_NAME>"
-最終更新: "YYYY-MM-DD"
+機能ID: "FEATURE-COPILOT-CLI-INTEGRATION"
+機能名: "GitHub Copilot CLI を sandbox ツールチェーンへ統合する"
+関連Issue: []
+状態: "draft"
+作成者: "Codex"
+最終更新: "2026-03-19"
 依存: ["requirement.md"]
 ---
 
-# <FEATURE_ID> <FEATURE_NAME> — 設計（HOW）
+# FEATURE-COPILOT-CLI-INTEGRATION GitHub Copilot CLI を sandbox ツールチェーンへ統合する — 設計（HOW）
 
 ## 目的・制約（要件から転記・圧縮） (必須)
-- 目的: ...
-- MUST: ...
-- MUST NOT: ...
-- 非交渉制約: ...
-- 前提: ...
+- 目的:
+  - GitHub Copilot CLI を既存 CLI 群と同じ sandbox 運用面に統合する
+  - `~/.copilot` を `.agent-home/.copilot` から bind mount して永続化する
+  - `sandbox copilot` を追加して tmux 経由で起動できるようにする
+- MUST:
+  - Dockerfile、docker-compose、`host/sandbox`、`package.json`、テストを連動して更新する
+  - Copilot CLI の標準ディレクトリを使う
+  - `sandbox copilot [options] -- [copilot args...]` の契約を明示し、`--` より後ろは `copilot` へ pass-through する
+- MUST NOT:
+  - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
+  - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
+  - Copilot 独自の認証/権限制御をラッパーに実装しない
+- 非交渉制約:
+  - 既存 `.agent-home` 設計と deterministic な stub テストを維持する
+  - 既存 CLI の挙動を壊さない
+- 前提:
+  - Node.js 24 で npm パッケージ `@github/copilot` を導入できる
+  - 標準ディレクトリは `~/.copilot`
 
 ---
 
 ## 既存実装/規約の調査結果（As-Is / 95%理解） (必須)
 - 参照した規約/実装（根拠）:
-  - `<path/to/doc_or_agents>`: <見た理由 / 採用するルール>
-  - `<path/to/file>`: <見た理由 / 仕様を決めている箇所（関数/クラス/行番号）>
+  - `AGENTS.md`: `print_help*` の更新、Bash-first、テストは stub ベースという規約
+  - `docker-compose.yml`: `.agent-home` から各 CLI 標準ディレクトリへの bind mount 定義
+  - `Dockerfile`: 各 CLI のホーム配下ディレクトリ事前作成、Node グローバルツール導入前提
+  - `package.json`: `install-global` / `verify` による共有ツール管理
+  - `host/sandbox`: `.agent-home` 初期化、compose 実行、help、`tools update`、`sandbox codex` の tmux 起動実装
+  - `tests/sandbox_cli.test.sh`: `help`、`.agent-home` 作成、`tools update`、`sandbox codex` の仕様テスト
 - 観測した現状（事実）:
-  - ...
+  - `.agent-home` の初期作成は `ensure_agent_home_dirs` に集中している
+  - Docker mount は `docker-compose.yml` の `volumes:` に集中している
+  - npm グローバルツールの導入は `package.json` と `sandbox tools update` のみで制御している
+  - tmux ラッパー付き専用サブコマンドは現状 `codex` のみ
 - 採用するパターン（命名/責務/例外/DI/テストなど）:
-  - ...
+  - 新しい CLI の永続化は `.agent-home/.<tool>` を作って標準ディレクトリに mount する
+  - ツール導入は `package.json` の `dependencies`、`install-global`、`verify` を揃えて更新する
+  - 専用サブコマンドは `print_help_<tool>`、`run_compose_exec_<tool>`、`compute_<tool>_session_name` のように分離し、`main()` に分岐を追加する
+  - tmux の有無、help の副作用なし、compose ログ確認は既存 codex テストに倣う
 - 採用しない/変更しない（理由）:
-  - ...
+  - Codex の Trust/YOLO/bootstrap 判定は Copilot に転用しない
+    - 理由: GitHub Copilot CLI の公式仕様で同等概念が確認できず、過剰なラッパー制御になるため
+  - `COPILOT_HOME` 環境変数で mount 先を切り替えない
+    - 理由: ユーザー要望と標準ディレクトリ運用に反するため
 - 影響範囲（呼び出し元/関連コンポーネント）:
-  - ...
+  - `sandbox --help` / `sandbox tools --help` / `sandbox copilot --help`
+  - `sandbox tools update`
+  - `sandbox build` / `up` / `shell` / `copilot` 前処理
+  - `tests/sandbox_cli.test.sh`
 
 ## 主要フロー（テキスト：AC単位で短く） (任意)
 - Flow for AC-001:
-  1) ...
-  2) ...
-  3) ...
+  1. `package.json` の `dependencies`、`install-global`、`verify` に Copilot CLI を追加する
+  2. `sandbox tools update` は既存と同じ `npm run install-global` を呼ぶ
+  3. `npm run verify` で `copilot --version` を追加確認する
 - Flow for AC-002:
-  1) ...
-  2) ...
-  3) ...
-
-## データ・バリデーション（必要最小限） (任意)
-- MODEL-001: <Entity/DTO/Table名>
-  - Fields: ...
-  - Constraints/Validation: ...
-- ...
+  1. `ensure_agent_home_dirs` に `.agent-home/.copilot` を追加する
+  2. `Dockerfile` で `/home/node/.copilot` を事前作成する
+  3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
+- Flow for AC-003:
+  1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
+  2. セッションが無ければ `SANDBOX_COPILOT_NO_TMUX=1 sandbox copilot ...` を新規セッション内で起動する
+  3. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
+  4. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
+  5. `docker compose exec -w <container_workdir> agent-sandbox /bin/zsh -lc 'copilot "$@"; exec /bin/zsh' -- ...` を実行する
+- Flow for AC-004:
+  1. help 表示時は `copilot` サブコマンドを認識する
+  2. ただちに help テキストだけを返し、副作用を起こさない
 
 ## 判断材料/トレードオフ（Decision / Trade-offs） (任意)
-- 論点: ...
-  - 選択肢A: ...（Pros/Cons）
-  - 選択肢B: ...（Pros/Cons）
-  - 決定: ...
-  - 理由: ...
+- 論点: `sandbox copilot` でコマンド名を固定するか、将来 `copilot agent` などに拡張可能な抽象化を先に入れるか
+  - 選択肢A: 初期実装では `copilot` 単体起動に固定する
+  - 選択肢B: 汎用エージェント起動ラッパーへ抽象化する
+  - 決定: 選択肢A
+  - 理由: 既存実装が CLI ごとの明示実装であり、変更範囲を最小にできるため
 
 ## インターフェース契約（ここで固定） (任意)
-### API（ある場合）
-- API-001: `<METHOD> <PATH>`
-  - Request: ...
-  - Response: ...
-  - Errors: ...
-
 ### 関数・クラス境界（重要なものだけ）
-- IF-001: `<module>::<function/class signature>`
-  - Input: ...
-  - Output: ...
-  - Errors/Exceptions: ...
+- IF-001: `host/sandbox::ensure_agent_home_dirs()`
+  - Input: なし
+  - Output: `.agent-home/.copilot` を含む必要ディレクトリが存在する
+  - Errors/Exceptions: 作成不能時は `mkdir -p` 失敗で終了
+- IF-002: `host/sandbox::run_compose_exec_copilot(container_workdir, container_name, compose_project_name, abs_mount_root, [copilot_args...])`
+  - Input: container workdir と compose 実行文脈、任意の Copilot 引数
+  - Output: コンテナ内で `copilot` を実行し、終了後 zsh に戻る
+  - Errors/Exceptions: compose exec 失敗時はその終了コードを返す
+- IF-005: `host/sandbox::split_copilot_args()`
+  - Input: `sandbox copilot` に渡された全引数
+  - Output: sandbox 側引数と `--` 以降の `copilot` 側引数を分離する
+  - Errors/Exceptions: `--` が無い場合は Copilot 引数を空配列として扱う
+- IF-003: `host/sandbox::compute_copilot_session_name()`
+  - Input: `CALLER_PWD`
+  - Output: `<sanitized-base>-copilot-sandbox`
+  - Errors/Exceptions: なし
+- IF-004: `host/sandbox::print_help_copilot()`
+  - Input: なし
+  - Output: `sandbox copilot` の usage と振る舞い説明を stdout へ出す
+  - Errors/Exceptions: なし
 
 ## 変更計画（ファイルパス単位） (必須)
 - 追加（Add）:
-  - `<path/to/new_file>`: <役割 / 責務>
+  - 該当なし
 - 変更（Modify）:
-  - `<path/to/existing_file>`: <何をどう変えるか>
+  - `package.json`: `@github/copilot` を dependencies、`install-global`、`verify` に追加する
+  - `Dockerfile`: `/home/node/.copilot` の事前作成と所有権設定を追加する
+  - `docker-compose.yml`: `.agent-home/.copilot:/home/node/.copilot` mount を追加し、Copilot 用の追加 XDG/config/cache mount は設けない
+  - `host/sandbox`: `.agent-home` 初期化、help、subcommand 判定、引数分離、tmux/compose ベースの `sandbox copilot [options] -- [copilot args...]` 実装を追加する
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストを追加・更新する
 - 削除（Delete）:
-  - `<path/to/obsolete_file>`: <なぜ削除するか>
+  - 該当なし
 - 移動/リネーム（Move/Rename）:
-  - `<from>` → `<to>`: <目的>
+  - 該当なし
 - 参照（Read only / context）:
-  - `<path/to/reference_file>`: <読む理由>
+  - `tests/_helpers.sh`: stub/fixture の前提確認
+  - `AGENTS.md`: 変更時の運用規約確認
 
 ## マッピング（要件 → 設計） (必須)
-- AC-001 → API-001, IF-001, `<path/...>`
-- EC-001 → `<path/...>`（エラー処理の場所）
-- 非交渉制約 → どの設計で満たすか（例: キャッシュ、冪等、監査ログなど）
+- AC-001 → `package.json`, `host/sandbox` (`tools update`), `tests/sandbox_cli.test.sh`
+- AC-002 → `host/sandbox::ensure_agent_home_dirs`, `Dockerfile`, `docker-compose.yml`, `tests/sandbox_cli.test.sh`
+- AC-003 → `host/sandbox::run_compose_exec_copilot`, `host/sandbox::compute_copilot_session_name`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
+- AC-003 → `host/sandbox::split_copilot_args`
+- AC-004 → `host/sandbox::print_help`, `host/sandbox::print_help_tools`, `host/sandbox::print_help_copilot`, `tests/sandbox_cli.test.sh`
+- EC-001 → `host/sandbox::ensure_tmux_available`, `tests/sandbox_cli.test.sh`
+- EC-002 → help 判定ロジック、`tests/sandbox_cli.test.sh`
+- EC-003 → 既存 `acquire_tools_update_lock` と `tools update` テストの非回帰確認
+- EC-004 → `host/sandbox::ensure_agent_home_dirs`, `Dockerfile`, `docker-compose.yml`, `tests/sandbox_cli.test.sh`
+- 非交渉制約 → `.agent-home` ディレクトリ全体 mount、既存 stub テストを継承、Copilot 独自制御を最小化
 
 ## テスト戦略（最低限ここまで具体化） (任意)
 - 追加/更新するテスト:
-  - Unit: ...
-  - Integration: ...
-  - Frontend: ...
+  - Unit: なし
+  - Integration:
+    - `help` に Copilot が反映されること
+    - `.agent-home/.copilot` が作成されること
+    - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
+    - `sandbox copilot -- --help` が `copilot --help` として pass-through されること
+    - tmux 未導入時にエラー終了すること
+  - Frontend: なし
 - どのAC/ECをどのテストで保証するか:
-  - AC-001 → `<test_file_path>::<test_name>`
-  - EC-001 → ...
+  - AC-001 → `tests/sandbox_cli.test.sh` の tools update / verify 関連更新
+    - `package.json` の `install-global` に `@github/copilot` が入ること
+    - `package.json` の `verify` に `copilot --version` が入ること
+  - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
+  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`
+  - AC-004 → 新規 `help_copilot_mentions_tmux`
+  - EC-001 → 新規 `copilot_errors_when_tmux_missing`
+  - EC-002 → `help` 系テスト
 - 非交渉制約（requirement.md）をどう検証するか:
-  - 制約: ...
-    - 検証方法（テスト/計測点/ログ/運用確認など）: ...
+  - 制約: 標準ディレクトリ `~/.copilot` を使用する
+    - 検証方法: `docker-compose.yml` mount 先と `Dockerfile` 作成先を確認する
+  - 制約: 既存 CLI の挙動を壊さない
+    - 検証方法: 既存 `tests/sandbox_cli.test.sh` を通す
 - 実行コマンド（該当するものを記載）:
-  - ...
+  - `bash tests/sandbox_cli.test.sh`
+  - 必要に応じて `npm run verify`（コンテナ内または build 後）
 - 変更後の運用（必要なら）:
-  - 移行手順: ...
-  - ロールバック: ...
-  - Feature flag: ...
+  - 移行手順: 既存 `.agent-home` に `.copilot` が無ければ自動生成される
+  - ロールバック: 変更を revert すれば Copilot 統合のみ除去可能
+  - Feature flag: 不要
 
 ## リスク/懸念（Risks） (任意)
-- R-001: <リスク>（影響: ... / 対応: ...）
-- R-002: ...
+- R-001: `sandbox copilot` 用の競合引数制御を入れない場合、将来 CLI 仕様変更に対し柔軟だがラッパー責務は薄くなる
+- R-002: help / tests / package install の3点を揃えないと統合の見た目だけ先行する
 
 ## 未確定事項（TBD） (必須)
-- Q-001:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: AC-___ / API-___ / IF-___ / `<path/...>` / テスト / ...
-- Q-002:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: ...
+- 該当なし
+
+## 合意済み決定事項 (任意)
+- D-001: `sandbox copilot` の CLI 契約は `sandbox copilot [options] -- [copilot args...]` とする
+- D-002: `--` より後ろの引数は検証や禁止を行わず、`copilot` へ pass-through する
+- D-003: `npm run verify` の Copilot 検証は `copilot --version` に固定する
 
 ---
 
 ## ディレクトリ/ファイル構成図（変更点の見取り図） (任意)
 ```text
 <repo-root>/
-├── <bounded-context-or-module>/
-│   └── <subdir>/
-│       ├── <path/to/new_file>        # Add
-│       ├── <path/to/existing_file>   # Modify
-│       ├── <path/to/obsolete_file>   # Delete
-│       ├── <from>                    # Move/Rename (from)
-│       └── <to>                      # Move/Rename (to)
-```
-
-## UML図（PlantUML） (任意)
-### コンポーネント図（境界/責務/依存の俯瞰）
-```plantuml
-@startuml
-actor User
-component "Web UI" as FE
-component "Backend API" as API
-database "DB" as DB
-cloud "External" as Ext
-
-User --> FE
-FE --> API : HTTP
-API --> DB : SQL
-API --> Ext : call
-@enduml
-```
-
-### シーケンス図（時系列・IFのやり取り）
-```plantuml
-@startuml
-actor User
-participant "Web UI" as FE
-participant "Backend API" as API
-database "DB" as DB
-
-User -> FE : 操作
-FE -> API : POST /...
-API -> DB : write
-API --> FE : 200 OK
-@enduml
-```
-
-### クラス図（主要ドメイン概念・責務）
-```plantuml
-@startuml
-class AggregateRoot
-class Entity
-class ValueObject
-AggregateRoot "1" o-- "*" Entity : contains
-AggregateRoot "1" o-- "*" ValueObject : owns
-@enduml
-```
-
-### アクティビティ図（主要フロー）
-```plantuml
-@startuml
-start
-:入力検証;
-if (OK?) then (yes)
-  :ユースケース実行;
-  :永続化/外部連携;
-  :成功応答;
-  stop
-else (no)
-  :エラー応答;
-  stop
-endif
-@enduml
-```
-
-### 状態マシン図（状態を持つドメインがある場合）
-```plantuml
-@startuml
-[*] --> Draft
-Draft --> Active : 確定
-Active --> Archived : 完了
-Archived --> [*]
-@enduml
-```
-
-### 配置図（デプロイ/ノード構成）
-```plantuml
-@startuml
-node "Client" as Client
-node "App Server" as App
-database "DB" as DB
-
-Client --> App
-App --> DB
-@enduml
-```
-
-### ユースケース図（機能境界とアクター）
-```plantuml
-@startuml
-left to right direction
-actor User
-rectangle System {
-  usecase "機能A" as UC1
-  usecase "機能B" as UC2
-}
-User --> UC1
-User --> UC2
-@enduml
-```
-
-### ER図（テーブル関係）
-```plantuml
-@startuml
-entity Tenant {
-  * id : uuid <<PK>>
-}
-entity LeaseContract {
-  * id : uuid <<PK>>
-  --
-  tenant_id : uuid <<FK>>
-}
-Tenant ||--o{ LeaseContract
-@enduml
+├── Dockerfile                         # Modify
+├── docker-compose.yml                 # Modify
+├── package.json                       # Modify
+├── host/
+│   └── sandbox                        # Modify
+├── tests/
+│   ├── _helpers.sh                    # Read only
+│   └── sandbox_cli.test.sh            # Modify
+└── .spec-dock/
+    └── current/
+        ├── requirement.md             # Modify
+        ├── design.md                  # Modify
+        └── plan.md                    # Modify
 ```
 
 ## 省略/例外メモ (必須)
-- 該当なし
+- UML図は今回の変更が Bash ベースの単一 CLI 統合であり、責務境界がファイル単位で十分追跡可能なため省略する

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -25,7 +25,7 @@
   - Copilot CLI の非対話経路では `docker compose exec -T` を使い、Compose 既定の TTY 割り当てを無効化する
   - `-p` / `--prompt` を使う programmatic 実行は、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` または `COPILOT_ALLOW_ALL` による承認オーバーライドがある場合にのみ非対話経路へ流す
   - 対話モードの `copilot` / `copilot --interactive` は TTY 前提のまま扱い、stdin または stdout が非 TTY の場合は非対話経路へ暗黙変換せず明示エラーにする
-  - `copilot help [topic]`、`version`、`-v/--version`、`init`、`update`、`plugin ...`、`login`、`logout`、stdin からオプション列を受ける headless invocation は tmux を使わず直接実行できる
+  - `copilot help [topic]`、`version`、`-v/--version`、`init`、`update`、`plugin ...`、`login`、`logout`、`--acp`、stdin からオプション列を受ける headless invocation は tmux を使わず直接実行できる
   - Copilot の tmux セッション名はワークスペースごとに衝突しない
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
@@ -82,10 +82,10 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、または stdin 非 TTYかつ引数空のケースを headless invocation とみなす
+  2. `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、`--acp`、または stdin 非 TTYかつ引数空のケースを headless invocation とみなす
   3. `-p` / `--prompt` を含む headless invocation では、`--allow-all-tools` / `--allow-tool ...` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` を検査する
   4. `-p` / `--prompt` で承認オーバーライドが揃っている場合のみ tmux をバイパスして `docker compose exec -T` の直接実行へ進む
-  5. `help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / stdin オプション入力の headless invocation は、承認オーバーライド不要で直接実行へ進む
+  5. `help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / `--acp` / stdin オプション入力の headless invocation は、承認オーバーライド不要で直接実行へ進む
   6. `-p` / `--prompt` で承認オーバーライドが無い場合は、必要なフラグまたは環境変数を案内して明示エラーにする
   7. headless invocation でない場合は対話モードとして扱い、`stdin` と `stdout` の両方が TTY のときだけ tmux セッションを生成または再利用する
   8. 対話モードで `stdin` または `stdout` のどちらかが非 TTY の場合は、非対話経路へ暗黙変換せず明示エラーにする
@@ -124,7 +124,7 @@
   - Errors/Exceptions: なし
 - IF-010: `host/sandbox::copilot_requests_headless_mode([copilot_args...])`
   - Input: `copilot` へ渡す引数配列と stdin の TTY 状態
-  - Output: `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、stdin オプション入力など、tmux を使わず直接実行すべき headless invocation かを判定する
+  - Output: `-p` / `--prompt`、`help`、`version`、`-v/--version`、`init`、`update`、`plugin`、`login`、`logout`、`--acp`、stdin オプション入力など、tmux を使わず直接実行すべき headless invocation かを判定する
   - Errors/Exceptions: なし
 - IF-008: `host/sandbox::copilot_has_approval_override([copilot_args...])`
   - Input: `copilot` へ渡す引数配列と `COPILOT_ALLOW_ALL`
@@ -158,9 +158,9 @@
   - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
   - `host/sandbox`: Copilot の非対話時は `docker compose exec -T` を使うよう修正し、stdout リダイレクト時も tmux をバイパスする
   - `host/sandbox`: Copilot の対話/非対話モードを明示判定し、対話モードで TTY が足りない場合は明示エラー、`-p` / `--prompt` では承認オーバーライドを必須化する
-  - `host/sandbox`: Copilot の headless invocation を `-p` / `--prompt` 以外にも拡張し、`help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / stdin オプション入力を tmux なしで直接実行できるようにする
+  - `host/sandbox`: Copilot の headless invocation を `-p` / `--prompt` 以外にも拡張し、`help` / `version` / `init` / `update` / `plugin ...` / `login` / `logout` / `--acp` / stdin オプション入力を tmux なしで直接実行できるようにする
   - `host/sandbox`: Copilot の tmux セッション名をフルパス由来のハッシュ付きに変更し、basename 衝突を避ける
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド別名、公式 headless サブコマンド、help/version の direct exec、stdin オプション入力、TTY 不足時の明示エラー、セッション名一意性、終了コード保持のテストを追加・更新する
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、承認オーバーライド別名、公式 headless サブコマンド、ACP、help/version の direct exec、stdin オプション入力、TTY 不足時の明示エラー、セッション名一意性、終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -190,7 +190,7 @@
     - `.agent-home/.copilot` が作成されること
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
     - `sandbox copilot -- --help` と `sandbox copilot -- --version` が direct exec として pass-through されること
-    - `sandbox copilot -- init` や `sandbox copilot -- plugin ...` などの公式サブコマンドが direct exec として pass-through されること
+    - `sandbox copilot -- init` や `sandbox copilot -- plugin ...`、`sandbox copilot -- --acp` などの公式 headless サブコマンド/フラグが direct exec として pass-through されること
     - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
     - stdin からオプション列を受ける `copilot` 実行が tmux を使わないこと
     - stdout リダイレクト付きの対話モードは明示エラーになること
@@ -205,7 +205,7 @@
     - `package.json` の `install-global` に `@github/copilot` が入ること
     - `package.json` の `verify` に `copilot --version` が入ること
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
-  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_session_name_disambiguates_same_basename_paths`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`, `copilot_init_uses_direct_exec`
+  - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_session_name_disambiguates_same_basename_paths`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`, `copilot_init_uses_direct_exec`, `copilot_acp_uses_direct_exec`
   - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`, `copilot_programmatic_requires_approval_override`, `copilot_programmatic_accepts_allow_all_aliases`, `copilot_stdin_option_stream_uses_direct_exec`
   - AC-003 → 新規 `copilot_redirected_stdout_errors_for_interactive_mode`
   - AC-004 → 新規 `help_copilot_mentions_tmux`

--- a/.spec-dock/current/design.md
+++ b/.spec-dock/current/design.md
@@ -22,6 +22,7 @@
   - `sandbox copilot [options] -- [copilot args...]` の契約を明示し、`--` より後ろは `copilot` へ pass-through する
   - Copilot CLI の非対話・programmatic 利用では tmux を自動バイパスし、標準入出力を親プロセスへ返す
   - `sandbox copilot` は Copilot CLI の終了コードを失わずに呼び出し元へ返す
+  - Copilot CLI の非対話経路では `docker compose exec -T` を使い、Compose 既定の TTY 割り当てを無効化する
 - MUST NOT:
   - `COPILOT_HOME` による別ディレクトリ設計を持ち込まない
   - `~/.copilot` 以外の追加 XDG/config/cache mount を推測で足さない
@@ -75,12 +76,12 @@
   3. `docker-compose.yml` で `.agent-home/.copilot:/home/node/.copilot` を mount する
 - Flow for AC-003:
   1. `sandbox copilot` 実行時、外側では tmux セッションの存在を確認する
-  2. 標準入出力が TTY であり、かつ programmatic mode を要求する引数が無い場合のみ tmux セッションを生成または再利用する
-  3. 標準入出力が非 TTY、または Copilot の programmatic mode を要求する場合は tmux をバイパスして直接コンテナ実行へ進む
+  2. `stdin` と `stdout` の両方が TTY であり、かつ programmatic mode を要求する引数が無い場合のみ tmux セッションを生成または再利用する
+  3. `stdin` または `stdout` のどちらかが非 TTY、または Copilot の programmatic mode を要求する場合は tmux をバイパスして直接コンテナ実行へ進む
   4. 内側フローでは `determine_paths`、Docker/Compose 準備、`run_compose_up`
   5. sandbox オプションは `--` の手前までで解釈し、`--` より後ろは `copilot` 引数として保持する
   6. 対話実行では `copilot` 成功時のみ zsh に戻し、失敗時は Copilot の終了コードで終了する
-  7. 非対話実行では `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
+  7. 非対話実行では `docker compose exec -T` で `copilot` だけを実行し、終了コードと標準入出力をそのまま返す
 - Flow for AC-004:
   1. help 表示時は `copilot` サブコマンドを認識する
   2. ただちに help テキストだけを返し、副作用を起こさない
@@ -100,7 +101,7 @@
   - Errors/Exceptions: 作成不能時は `mkdir -p` 失敗で終了
 - IF-002: `host/sandbox::run_compose_exec_copilot(container_workdir, container_name, compose_project_name, abs_mount_root, [copilot_args...])`
   - Input: container workdir と compose 実行文脈、任意の Copilot 引数
-  - Output: コンテナ内で `copilot` を実行し、対話実行では成功時のみ zsh に戻る
+  - Output: コンテナ内で `copilot` を実行し、対話実行では成功時のみ zsh に戻る。非対話実行では `-T` 付き exec で標準入出力を親へ返す
   - Errors/Exceptions: Copilot または compose exec の終了コードをそのまま返す
 - IF-005: `host/sandbox::split_copilot_args()`
   - Input: `sandbox copilot` に渡された全引数
@@ -132,7 +133,8 @@
   - `docker-compose.yml`: `.agent-home/.copilot:/home/node/.copilot` mount を追加し、Copilot 用の追加 XDG/config/cache mount は設けない
   - `host/sandbox`: `.agent-home` 初期化、help、subcommand 判定、引数分離、tmux/compose ベースの `sandbox copilot [options] -- [copilot args...]` 実装を追加する
   - `host/sandbox`: Copilot の非対話時 tmux バイパスと、Copilot 終了コードを保持する実行ラッパーに修正する
-  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパスと終了コード保持のテストを追加・更新する
+  - `host/sandbox`: Copilot の非対話時は `docker compose exec -T` を使うよう修正し、stdout リダイレクト時も tmux をバイパスする
+  - `tests/sandbox_cli.test.sh`: help、`.agent-home`、`sandbox copilot`、tmux なしエラー等のテストに加えて、非対話バイパス、`-T` 利用、stdout リダイレクト時バイパス、終了コード保持のテストを追加・更新する
 - 削除（Delete）:
   - 該当なし
 - 移動/リネーム（Move/Rename）:
@@ -163,6 +165,8 @@
     - `sandbox copilot` の tmux 外側起動と内側 compose exec 起動
     - `sandbox copilot -- --help` が `copilot --help` として pass-through されること
     - `echo ... | sandbox copilot ...` のような非対話実行で tmux を使わないこと
+    - stdout リダイレクトやコマンド置換でも tmux を使わないこと
+    - 非対話実行では `docker compose exec -T` が使われること
     - 非対話実行時に Copilot の失敗終了コードが保持されること
     - tmux 未導入時にエラー終了すること
   - Frontend: なし
@@ -173,6 +177,7 @@
   - AC-002 → `tests/sandbox_cli.test.sh` の `.agent-home` 作成確認更新
   - AC-003 → 新規 `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`
   - AC-003 → 新規 `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+  - AC-003 → 新規 `copilot_redirected_stdout_bypasses_tmux`
   - AC-004 → 新規 `help_copilot_mentions_tmux`
   - EC-001 → 新規 `copilot_errors_when_tmux_missing`
   - EC-002 → `help` 系テスト

--- a/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-02.md
+++ b/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-02.md
@@ -1,0 +1,190 @@
+---
+種別: ディスカッションメモ
+題名: "GitHub Copilot CLI PR レビュー指摘の妥当性分析 その2"
+作成者: "Codex"
+作成日: "2026-03-19"
+関連: ["issue #10", "PR review comments on host/sandbox"]
+---
+
+# GitHub Copilot CLI PR レビュー指摘の妥当性分析 その2
+
+## 結論
+- Review-03 は「一部妥当だが、指摘どおりの修正をそのまま採るべきとは限らない」です。
+- Review-04 は概ね妥当で、少なくとも追加のガードまたは仕様明文化が必要です。
+
+## 対象レビュー
+
+### Review-03
+- 指摘:
+  - `copilot_should_use_tmux()` が `stdout` 非 TTY を理由に tmux を外すと、`sandbox copilot -- --interactive ... | tee ...` や `sandbox copilot > transcript.txt` のようなケースでも interactive UI が起動できなくなる
+- 指摘重大度:
+  - レビュー上は `P2`
+
+### Review-04
+- 指摘:
+  - `-p/--prompt` を programmatic mode とみなして非対話経路へ送るだけでは不十分
+  - GitHub Docs 上、programmatic usage では `--allow-all-tools` または `COPILOT_ALLOW_ALL` などの approval 設定が必要
+  - approval が必要なタスクを非対話経路へ送ると、承認不能で失敗または停止する
+- 指摘重大度:
+  - レビュー上は `P2`
+
+## 一次情報
+
+### GitHub Docs: Copilot CLI の programmatic interface
+- 2026-03-19 時点で GitHub Docs には、`-p` / `--prompt` で programmatic に実行できることが明記されています。
+- 同時に、「Copilot にファイル変更やコマンド実行をさせるなら approval option も使うべき」とあります。
+- 例:
+  - `copilot -p "Show me this week's commits and summarize them" --allow-tool 'shell(git)'`
+- 参照:
+  - https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli
+
+### GitHub Docs: approval option
+- `--allow-all-tools`
+- `--allow-tool`
+- `--deny-tool`
+- command reference 側では、`--allow-all-tools` は "Required when using the CLI programmatically" と読める説明が載っています。
+- 環境変数 `COPILOT_ALLOW_ALL` でも指定可能です。
+- 参照:
+  - https://docs.github.com/en/free-pro-team@latest/copilot/reference/cli-command-reference
+  - https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli
+
+## 妥当性分析
+
+## Review-03: `stdout` 非 TTY でも interactive mode は tmux を維持すべきか
+
+### 判断
+- 指摘の問題意識は妥当です。
+- ただし「stdout 非 TTY なら必ず tmux を使うべき」という結論までは、そのまま採らない方がよいです。
+
+### 妥当な点
+- `copilot --interactive` や plain `copilot` は本質的に TTY を必要とする interactive UI です。
+- この interactive mode を、stdout リダイレクトだけを理由に `exec -T` な非対話経路へ送ると、UI が成立しない可能性は高いです。
+- したがって「stdout 非 TTY なら常に非対話扱い」は雑すぎます。
+
+### そのまま採れない点
+- 一方で、stdout リダイレクトや command substitution は「呼び出し元が stdout を消費したい」シグナルでもあります。
+- そこへ tmux を強制すると、出力は tmux pane 側へ流れ、リダイレクト先には期待した内容が来ません。
+- つまり、以下の2つは両立しません。
+  - interactive UI を成立させたい
+  - stdout を機械的に取得したい
+
+### 実装上の論点
+- `stdout` 非 TTYを見た時点で、その呼び出しが「interactive launcher を期待している」のか「programmatic capture を期待している」のかは、引数情報なしには完全には分かりません。
+- そのため、単純に
+  - A. `stdout` 非 TTYなら常に非対話
+  - B. `stdout` 非 TTYでも常に tmux
+  のどちらかに固定すると、片方のユースケースを壊します。
+
+### 推奨判断
+- 修正は必要です。
+- ただし対策は「tmux を使う」に戻すだけでは不十分です。
+
+### 推奨対策案
+- interactive mode を明示するフラグがある場合は、stdout 非 TTYでも「非対話へ落とす」のではなく、明示エラーにする。
+  - 例:
+    - `sandbox copilot: interactive mode requires a TTY on stdout; remove redirection or use -p/--prompt`
+- plain `copilot` で stdout 非 TTY の場合も、同様に
+  - 非対話へ暗黙変換するのではなく
+  - interactive mode 不能としてエラーにする方が契約は明確
+- 一方、programmatic mode (`-p`, `--prompt`) が明示されている場合だけ、stdout 非 TTY でも非対話 `exec -T` に進める
+
+### まとめ
+- このレビューは「stdout 非 TTYなら常に非対話」は危険、という点で妥当です。
+- ただし実際の対策は「tmux 維持」ではなく、「interactive mode と noninteractive mode を明示的に分け、曖昧なケースはエラーにする」がより堅いです。
+
+---
+
+## Review-04: `-p` を非対話対応とみなすなら approval option も考慮すべきか
+
+### 判断
+- 概ね妥当です。
+
+### 理由
+- 現在のラッパーは `-p/--prompt` を見つけると noninteractive route へ送ります。
+- しかし Copilot がツール実行やファイル編集を要するタスクを行う場合、approval が必要になることがあります。
+- 非対話経路では、その approval prompt にユーザーが応答できません。
+- そのため、以下の事象が起こり得ます。
+  - 実行失敗
+  - 承認待ちで停止
+  - 期待した自動化ワークフローにならない
+
+### 指摘の強さについて
+- 「必ず `--allow-all-tools` が必要」とまでは、文脈上は少し強すぎます。
+- 正確には:
+  - programmatic usage では approval option の利用が強く推奨または事実上必要
+  - 少なくとも、ツール利用が発生するタスクでは approval 設定が無いと非対話では成立しにくい
+- したがって、レビューの方向性は正しいです。
+
+### 対策要否
+- 必要です。
+
+### 推奨対策案
+- 最小対策:
+  - `-p/--prompt` で非対話扱いにする場合、approval option が無いときは明示エラーにする
+  - 例:
+    - `--allow-all-tools`
+    - `--allow-tool=...`
+    - `--allow-all`
+    - `--yolo`
+    - `COPILOT_ALLOW_ALL`
+- もう一段強い対策:
+  - `-p/--prompt` で approval option が無い場合は、非対話 route に送らず interactive route に残す
+  - ただしこれは scriptability を下げるため、明示エラーの方が分かりやすい
+
+### 推奨メッセージ例
+```text
+sandbox copilot: programmatic mode (-p/--prompt) without approval flags is not supported in noninteractive mode.
+Pass --allow-all-tools, --allow-tool=..., --allow-all, or set COPILOT_ALLOW_ALL.
+```
+
+### 追加テスト案
+- `copilot_programmatic_without_approval_flags_errors`
+  - `-p` のみ指定して noninteractive 実行すると明示エラーになる
+- `copilot_programmatic_with_allow_all_tools_bypasses_tmux`
+  - `-p --allow-all-tools` なら `exec -T` 経路へ進む
+- `copilot_programmatic_with_env_allow_all_bypasses_tmux`
+  - `COPILOT_ALLOW_ALL=1` なら同様に許可
+
+## 優先度評価
+
+### Review-03
+- `P2` は妥当です。
+- 契約の曖昧さと mode 判定の粗さに関する問題であり、致命的ではないが scriptability と interactive usability の境界を壊します。
+
+### Review-04
+- `P2` は妥当、内容次第では `P1` 寄りです。
+- 非対話 `-p` の主要用途そのものに関わるため、放置すると「動くが実運用で詰まる」タイプの不具合になります。
+
+## 推奨対応方針
+
+### 対応が必要な点
+1. `stdout` 非 TTYだけで即 noninteractive route に落とさない
+2. interactive mode を stdout 非 TTYで呼んだ場合の振る舞いを明文化する
+3. `-p/--prompt` を noninteractive route に送るなら approval option の有無を検査する
+
+### 実装の方向性
+- `copilot_should_use_tmux()` を二段階判定に分ける
+  - interactive mode 判定
+  - programmatic mode 判定
+- `stdout` 非 TTYかつ programmatic mode でない場合:
+  - tmux へ送るのではなく、明示エラー
+- `-p/--prompt` かつ approval option なし:
+  - 明示エラー
+- `-p/--prompt` かつ approval option あり:
+  - `exec -T` で noninteractive 実行
+
+## まとめ
+- Review-03:
+  - 妥当
+  - ただし「tmux に戻す」だけではなく、interactive/stdout-redirect の曖昧ケースを明示エラーにする方向が望ましい
+- Review-04:
+  - 概ね妥当
+  - 非対話 `-p` をサポートするなら approval flag / env の検査は入れるべき
+
+## 参照
+- About GitHub Copilot CLI
+  - https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli
+- Configure GitHub Copilot CLI
+  - https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli
+- GitHub Copilot CLI command reference
+  - https://docs.github.com/en/free-pro-team@latest/copilot/reference/cli-command-reference

--- a/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-03.md
+++ b/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-03.md
@@ -1,0 +1,139 @@
+# 2026-03-19 Copilot Review Analysis 03
+
+## 対象レビュー
+
+### Review-05
+- 指摘:
+  - `copilot_has_approval_override()` が `--allow-all` と `--yolo` を承認オーバーライドとして認識していない
+- 対象箇所:
+  - [host/sandbox](/Users/iwasawayuuta/workspace/box/host/sandbox)
+
+### Review-06
+- 指摘:
+  - `copilot_requests_programmatic_mode()` が `-p/--prompt` しか見ておらず、stdin 経由のオプション入力や `copilot help [topic]` / `--version` のような非対話エントリポイントを非対話扱いできていない
+- 対象箇所:
+  - [host/sandbox](/Users/iwasawayuuta/workspace/box/host/sandbox)
+
+## 一次情報
+
+- GitHub Copilot CLI command reference
+  - `--allow-all` は `--allow-all-tools --allow-all-paths --allow-all-urls` と等価
+  - `--yolo` は `--allow-all` と等価
+  - `--allow-all-tools` は programmatic usage で必要
+  - `copilot help [topic]` と `-v/--version` は独立したヘッドレスなコマンド/フラグ
+  - 出典:
+    - https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- About GitHub Copilot CLI
+  - programmatic interface は `-p/--prompt` だけでなく、オプション列を出力するスクリプトを `./script-outputting-options.sh | copilot` のように stdin で流す方法も案内されている
+  - 出典:
+    - https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli
+
+## 妥当性評価
+
+### Review-05: `--allow-all` / `--yolo` 未認識
+- 判定: 妥当
+- 理由:
+  - 公式リファレンスで `--allow-all` と `--yolo` は明示的に承認オーバーライドとして定義されている
+  - 現在の wrapper は `--allow-all-tools` と `--allow-tool`、`COPILOT_ALLOW_ALL` しか見ていないため、公式に有効なフラグを wrapper 側で先に弾いてしまう
+  - これは Copilot CLI 本体の正当な呼び出しを wrapper が不当に狭めている
+- 重大度見立て:
+  - `P2` は妥当
+  - programmatic 実行の一部の正式フラグが使えず、CI やスクリプト化の互換性を損なう
+- 対処要否:
+  - 必要
+
+### Review-06: stdin/help/version を非対話エントリポイントとして扱えていない
+- 判定: 概ね妥当
+- 理由:
+  - `copilot help [topic]` と `--version` は公式の独立コマンド/フラグであり、tmux セッションを作って `exec /bin/zsh` に戻るのは過剰
+  - 公式ドキュメントは stdin からオプション列を `copilot` に流す使い方も示しているため、wrapper が `stdin 非 TTY = 対話失敗` とだけ扱うのは狭すぎる
+  - 現在の `validate_copilot_invocation()` は `-p/--prompt` を伴わない stdin パイプをすべて対話モード失敗として扱うため、公式の headless entry point と矛盾する
+- 注意点:
+  - stdin パイプは「常に無条件許可」でよいとは限らない
+  - stdin に流れてくる内容が `--allow-all` などを含む場合、wrapper は事前に引数列を見られない
+  - したがって「stdin パイプを完全に検査してから許可する」のは難しい
+  - ここは wrapper の責務と Copilot CLI 本体の責務を切り分けて設計する必要がある
+- 重大度見立て:
+  - `P2` は妥当
+  - `help` / `version` のような明確な非対話ケースも現状は対話経路へ寄っており、wrapper の UX と自動化適性を下げている
+- 対処要否:
+  - 必要
+
+## 推奨対策
+
+### 対策A: 承認オーバーライド判定を公式同等に拡張する
+- `copilot_has_approval_override()` に以下を追加する
+  - `--allow-all`
+  - `--allow-all=*`
+  - `--yolo`
+  - `--yolo=*`
+- 実質的には `--allow-all-tools` / `--allow-tool` / `--allow-all` / `--yolo` / `COPILOT_ALLOW_ALL` のいずれかを許可条件とする
+- 方針:
+  - wrapper 独自の approval model は増やさず、公式で承認オーバーライドとして定義されたものだけを通す
+
+### 対策B: 非対話エントリポイントを `-p/--prompt` 以外にも拡張する
+- 少なくとも以下は「tmux ではなく直接実行」に寄せるべき
+  - `--version`
+  - `-v`
+  - `version`
+  - `help`
+- これらは tool approval を伴わない参照系コマンドなので、非対話 direct path に安全に流しやすい
+
+### 対策C: stdin パイプ入力は `-p` 検出だけで判定しない
+- 推奨:
+  - `stdin` 非 TTYかつ `copilot` 引数が空、または `help` / `version` 系なら direct path を許可する
+  - `stdin` 非 TTYかつ引数があり、かつそれが明らかに対話モードではない場合も direct path を検討する
+- 設計上の注意:
+  - stdin から渡されたオプション列の中身を wrapper が事前検証できないため、approval requirement の最終判定は Copilot CLI 本体に委ねる場面が残る
+  - つまり stdin パイプ入力は「wrapper が検査して許可する経路」ではなく、「tmux に入れず直接実行し、本体に解釈させる経路」として扱うのが現実的
+
+## 実装修正の方向性
+
+### `copilot_has_approval_override()`
+- 追加候補:
+  - `--allow-all`
+  - `--yolo`
+  - 必要なら `--allow-all=*` / `--yolo=*` を許容するパターンも入れる
+
+### `copilot_requests_programmatic_mode()` の見直し
+- 現状:
+  - `-p/--prompt` だけを programmatic mode と判定
+- 推奨:
+  - 関数名/責務を広げる
+  - 例:
+    - `copilot_should_use_direct_exec()`
+    - `copilot_is_headless_invocation()`
+- 判定対象:
+  - `-p`, `--prompt`
+  - `help`, `version`, `-v`, `--version`
+  - `stdin` 非 TTYかつ引数空
+
+### `validate_copilot_invocation()` の見直し
+- 参照系 direct path:
+  - `help` / `version` は承認オーバーライド不要で直接実行
+- programmatic direct path:
+  - `-p/--prompt` は承認オーバーライドがある場合のみ wrapper で許可
+  - ただし stdin パイプでオプション列そのものを渡すケースは wrapper から完全検査できないため、tmux を避けて本体に任せる方が自然
+- interactive path:
+  - `copilot` のみ、または `--interactive` を含むケースは TTY 必須
+
+## 結論
+
+- Review-05:
+  - 妥当
+  - 修正が必要
+- Review-06:
+  - 概ね妥当
+  - 修正が必要
+  - ただし「stdin パイプ入力をどう安全に扱うか」は wrapper 側で事前検査しきれないため、`help` / `version` / 引数空パイプを direct path に逃がし、それ以外は Copilot 本体へ委ねる設計整理が必要
+
+## 次のアクション案
+
+1. 設計書を更新して、Copilot の direct path 条件を「programmatic mode」から「headless invocation」に整理し直す
+2. 実装計画書に追加ステップを積み、`--allow-all` / `--yolo` と `help` / `version` / stdin パイプ対応を追加する
+3. テストを追加する
+   - `sandbox copilot -- --version` が tmux を使わず終了する
+   - `sandbox copilot -- help` が tmux を使わず終了する
+   - `sandbox copilot -- -p ... --allow-all` を許可する
+   - `sandbox copilot -- -p ... --yolo` を許可する
+   - `printf '%s\n' --version | sandbox copilot` のような stdin 経由を direct path に流す

--- a/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-04.md
+++ b/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-04.md
@@ -1,0 +1,124 @@
+# 2026-03-19 Copilot Review Analysis 04
+
+## 対象レビュー
+
+### Review-07
+- 指摘:
+  - `copilot_requests_headless_mode()` が `help` / `version` しか headless 扱いしておらず、`init` / `update` / `plugin ...` / `login` / `logout` などの公式トップレベルコマンドを非TTY環境で弾いてしまう
+
+### Review-08
+- 指摘:
+  - `compute_copilot_session_name()` が `basename "$CALLER_PWD"` しか使っていないため、別ディレクトリでも basename が同じなら tmux セッションが衝突する
+
+### Review-09
+- 指摘:
+  - テストの `script -q /dev/null /bin/bash -lc ...` は util-linux 版 `script` では `/bin/bash` が typescript file 扱いされるため移植性が低く、`--command` または `-c` を使うべき
+
+## 一次情報 / 根拠
+
+- GitHub Copilot CLI command reference:
+  - `copilot init`
+  - `copilot update`
+  - `copilot version`
+  - `copilot login`
+  - `copilot logout`
+  - `copilot plugin`
+  - 出典:
+    - https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- GitHub Copilot CLI plugin reference:
+  - `copilot plugin install|uninstall|list|update|disable|enable`
+  - 出典:
+    - https://docs.github.com/en/enterprise-cloud@latest/copilot/reference/cli-plugin-reference
+- `script --help` の系統差:
+  - 現在のローカル環境は BSD `script` で `script [-aeFkpqr] [-t time] [file [command ...]]`
+  - util-linux 系は `--command` / `-c` を明示する構文が一般的
+  - レビュー指摘は Ubuntu/util-linux 互換性の観点
+
+## 妥当性評価
+
+### Review-07: 公式トップレベルコマンドを headless 扱いしていない
+- 判定: 妥当
+- 理由:
+  - 公式リファレンスに `init`, `update`, `version`, `login`, `logout`, `plugin` が独立コマンドとして列挙されている
+  - 現在の wrapper は `help` / `version` / stdin オプション入力しか direct exec に流していない
+  - そのため `sandbox copilot -- init` のような呼び出しが、非TTY環境だと「interactive なのに TTY が無い」と誤判定される余地がある
+- 注意点:
+  - `login` 自体は OAuth device flow を伴うので、意味上は対話的な場面もある
+  - ただし wrapper の責務は tmux UI 強制ではなく、Copilot CLI 本体へ正式サブコマンドを正しく転送することなので、tmux 前提で縛るべきではない
+- 優先度見立て:
+  - `P2` は妥当
+- 対処要否:
+  - 必要
+
+### Review-08: tmux セッション名が basename だけで衝突する
+- 判定: 妥当
+- 理由:
+  - 現在の `compute_copilot_session_name()` は `basename "$CALLER_PWD"` しか使っていない
+  - `/work/foo/app` と `/tmp/bar/app` は両方 `app-copilot-sandbox` になり、別プロジェクトでも同一 tmux セッションを共有してしまう
+  - これは期待動作ではなく、誤ったプロジェクトの Copilot セッションへ入る不具合になる
+- 補足:
+  - 同じパターンは `compute_codex_session_name()` にもある
+  - 今回の PR レビュー対象は Copilot だが、根本原因は共通ロジックの設計にある
+- 優先度見立て:
+  - `P2` は妥当
+- 対処要否:
+  - 必要
+
+### Review-09: `script` テストの util-linux 互換性不足
+- 判定: 妥当
+- 理由:
+  - 現在のテストは BSD/macOS では動くが、レビュー指摘の通り util-linux の `script` とは引数解釈が異なる
+  - このリポジトリは Dockerfile 上で Ubuntu 系コンテナ環境を扱っており、Linux 系実行環境でテストが落ちる可能性は現実的
+  - テストがレビュー指摘の再現確認にならないのは品質上の問題
+- 優先度見立て:
+  - `P2` は妥当
+- 対処要否:
+  - 必要
+
+## 推奨対策
+
+### 対策A: headless サブコマンドの範囲を広げる
+- `copilot_requests_headless_mode()` に少なくとも以下を追加する
+  - `init`
+  - `update`
+  - `plugin`
+  - `login`
+  - `logout`
+  - 既存の `help`, `version`, `-v`, `--version`, `--help`
+- 方針:
+  - 「interactive UI を開始する `copilot` 本体」以外の公式トップレベルサブコマンドは原則 direct exec として扱う
+
+### 対策B: tmux セッション名をフルパス由来に変える
+- `basename "$CALLER_PWD"` だけでなく、`CALLER_PWD` 全体を sanitize して使う
+- 例:
+  - フルパスを sanitize した上で長さ制限のために hash を付ける
+  - 形式例:
+    - `<basename>-<short-hash>-copilot-sandbox`
+    - `<sanitized-full-path-hash>-copilot-sandbox`
+- 実用上は basename と hash の組み合わせが見やすい
+
+### 対策C: `script` テストを util-linux / BSD 両対応にする
+- 優先案:
+  - `script --command` または `script -c` を使える場合はその形式を優先
+  - BSD 版では従来形式へフォールバックする小さな helper をテスト内に置く
+- 目的:
+  - テストをホスト依存にせず、Linux/macOS の両方で通る形にする
+
+## 結論
+
+- Review-07:
+  - 妥当
+  - 修正が必要
+- Review-08:
+  - 妥当
+  - 修正が必要
+- Review-09:
+  - 妥当
+  - 修正が必要
+
+## 次の実装メモ
+
+1. `copilot_requests_headless_mode()` を「公式トップレベルサブコマンドは direct exec」と読める判定に整理する
+2. `compute_copilot_session_name()` はフルパスベースの一意化へ変更する
+3. 可能なら `compute_codex_session_name()` も同時に同じ衝突回避方式へ揃えるか、少なくとも影響を明記する
+4. `tests/sandbox_cli.test.sh` に `script` 呼び出し helper を入れて util-linux/BSD 両対応にする

--- a/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-05.md
+++ b/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-05.md
@@ -1,0 +1,85 @@
+# 2026-03-19 Copilot Review Analysis 05
+
+## 対象レビュー
+
+### Review-10
+- 指摘:
+  - `copilot_requests_headless_mode()` が `--acp` を headless invocation として扱っていない
+
+### Review-11
+- 指摘:
+  - `run_in_pseudo_tty()` が util-linux `script` 実行時に `-e/--return` を付けておらず、子プロセスの終了コードを返さない
+
+## 一次情報
+
+- GitHub Copilot CLI command reference
+  - `--acp` は `Start the Agent Client Protocol server.`
+  - 出典:
+    - https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- Copilot CLI ACP server docs
+  - `copilot --acp --stdio`
+  - `copilot --acp --port 3000`
+  - ACP サーバーは stdio または TCP で外部クライアントと接続する前提
+  - 出典:
+    - https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server
+- util-linux `script`
+  - `-e`, `--return` は child process の exit code を返すためのオプション
+  - レビュー指摘は Ubuntu 系 CI での util-linux 挙動に基づく
+
+## 妥当性評価
+
+### Review-10: `--acp` を headless 扱いしていない
+- 判定: 妥当
+- 理由:
+  - `--acp` は ACP server を開始する公式フラグで、interactive shell や tmux UI へ入る性質のものではない
+  - 公式ドキュメントも stdio/TCP 経由で他クライアントから接続する headless 運用として説明している
+  - 現在の wrapper は `--acp` を対話モード寄りに誤判定するため、`sandbox copilot -- --acp` が TTY エラーになるか、tmux に巻かれる可能性がある
+- 優先度見立て:
+  - `P2` は妥当
+- 対処要否:
+  - 必要
+
+### Review-11: `run_in_pseudo_tty()` が util-linux で子プロセスの終了コードを返さない
+- 判定: 妥当
+- 理由:
+  - util-linux `script` では `-e/--return` が無いと `script` 自身の終了コードが返りやすく、子プロセスの non-zero を取りこぼす
+  - 現在の `copilot_redirected_stdout_errors_for_interactive_mode` は終了コードを評価しているため、Linux 系ではテストの観測点がずれる
+  - これは「テストが失敗する/成功する理由」が本来の wrapper の挙動ではなく `script` の既定動作になる、という意味で妥当な指摘
+- 優先度見立て:
+  - `P2` は妥当
+- 対処要否:
+  - 必要
+
+## 推奨対策
+
+### 対策A: `--acp` を headless invocation として追加する
+- `copilot_requests_headless_mode()` に `--acp` を追加する
+- 必要なら `--stdio` / `--port` は `--acp` と組み合わせてそのまま本体へ渡す
+- 方針:
+  - ACP は stdio/TCP の direct stdio が必要なので、tmux 経路には入れない
+
+### 対策B: `run_in_pseudo_tty()` の util-linux 経路で `-e` を使う
+- 例:
+  - `script -q -e -c "$command_string" /dev/null >/dev/null`
+- 互換方針:
+  - `script -q -e -c ...` が使える環境ではそれを優先
+  - BSD 版では従来のフォールバックを維持する
+- 目的:
+  - Linux/macOS の両方で「子プロセスの終了コード」を正しく観測する
+
+## 結論
+
+- Review-10:
+  - 妥当
+  - 修正が必要
+- Review-11:
+  - 妥当
+  - 修正が必要
+
+## 次の修正メモ
+
+1. `design.md` に ACP server を headless invocation として追記する
+2. `plan.md` に追加修正ステップを積むか、既存 S09 の追補として扱う
+3. `host/sandbox` の `copilot_requests_headless_mode()` に `--acp` を追加する
+4. `tests/sandbox_cli.test.sh` の `run_in_pseudo_tty()` で util-linux 経路に `-e` を追加する
+5. 可能なら `copilot_acp_uses_direct_exec` のようなテストを追加する

--- a/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis.md
+++ b/.spec-dock/current/discussions/2026-03-19-copilot-review-analysis.md
@@ -1,0 +1,186 @@
+---
+種別: ディスカッションメモ
+題名: "GitHub Copilot CLI PR レビュー指摘の妥当性分析"
+作成者: "Codex"
+作成日: "2026-03-19"
+関連: ["issue #10", "PR review comments on host/sandbox"]
+---
+
+# GitHub Copilot CLI PR レビュー指摘の妥当性分析
+
+## 結論
+- 2件とも妥当です。
+- 1件目は少なくとも `P1` 相当として受けるべき内容です。
+- 2件目は少なくとも `P2`、実運用上は `P1` 寄りの内容です。
+- どちらも `sandbox copilot` を「対話ラッパー」としては成立させていても、「Copilot CLI の programmatic / scripting usage」を壊すため、修正が必要です。
+
+## 対象レビュー
+
+### Review-01
+- 指摘:
+  - `docker compose exec` の非対話 Copilot 実行で `-T` を付けていないため、tmux を避けても Compose 側がデフォルトで TTY を割り当ててしまう
+  - 結果として、`printf ... | sandbox copilot -- -- -p ...` や CI 実行で TTY 前提の失敗、TTY フォーマット混入、入出力契約の崩れが起こり得る
+- 指摘重大度:
+  - レビュー上は `P1`
+
+### Review-02
+- 指摘:
+  - `copilot_should_use_tmux()` が `stdin` しか見ておらず、`stdout` のリダイレクトやコマンド置換を検知できない
+  - そのため `sandbox copilot ... > out.txt` や `result=$(sandbox copilot ...)` でも tmux 側へ出力が流れ、呼び出し元が結果を受け取れない
+- 指摘重大度:
+  - レビュー上は `P2`
+
+## 一次情報
+
+### Docker Compose exec の TTY デフォルト
+- Docker Docs の `docker compose exec` には、「コマンドはデフォルトで TTY を割り当てる」と明記されています。
+- また `-T, --no-tty` は pseudo-TTY allocation を無効化するオプションです。
+- 2026-03-19 時点で確認した公式ドキュメント:
+  - https://docs.docker.com/compose/reference/exec
+
+要点:
+- By default, Compose will enter container in interactive mode and allocate a TTY.
+- `-T` で TTY 無効化が必要。
+
+## 妥当性分析
+
+### 1. `docker compose exec` 非対話経路で `-T` が必要か
+
+#### 判断
+- 妥当です。
+
+#### 理由
+- 現在の修正案では、tmux をバイパスしても `run_compose exec ...` のままであり、Compose のデフォルト TTY 割り当ては残ります。
+- つまり「tmux を避けた」だけで、「非対話・スクリプト実行に適した I/O 条件」にはまだなっていません。
+- `copilot -p`、パイプ入力、CI などの programmatic use case では、TTY なし・素の stdin/stdout/stderr を期待するのが自然です。
+- ここで TTY が残ると、少なくとも以下のリスクがあります。
+  - TTY が必要な前提で失敗する
+  - 出力が装飾される
+  - 呼び出し元の pipe / redirect と噛み合わない
+
+#### 対策要否
+- 必要です。
+
+#### 推奨対策
+- Copilot の非対話経路では `docker compose exec -T ...` を使う。
+- 対話経路では従来通り TTY ありでよい。
+
+#### 技術的実装案
+- `run_compose_exec_copilot()` を対話/非対話で分岐し、非対話時は以下の形にする。
+
+```bash
+run_compose exec -T -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"' -- "$@"
+```
+
+- 対話時は引き続き `-T` なし。
+- 実装上は `interactive_mode=true/false` を受ける現在の関数設計に素直に乗せられる。
+
+#### 追加テスト案
+- `copilot_noninteractive_bypasses_tmux` に加えて、compose ログに `exec -T -w ...` が出ることを検証する。
+- `copilot_noninteractive_preserves_exit_status` でも `-T` が付いていることを確認する。
+
+---
+
+### 2. `stdin` だけでなく `stdout` リダイレクトも tmux バイパス条件に含めるべきか
+
+#### 判断
+- 妥当です。
+
+#### 理由
+- 現在の判定は `! -t 0` に寄せており、「stdin が非 TTYなら非対話」とみなしています。
+- しかし以下のケースでは stdin は TTY のままでも、呼び出し元は「標準出力を受け取りたい非対話用途」です。
+  - `sandbox copilot ... > out.txt`
+  - `result=$(sandbox copilot -- -- -p ... -s)`
+  - `sandbox copilot ... | jq ...`
+- このとき stdout が TTY でなければ、tmux に入る設計は不整合です。
+- tmux に attach/switch すると、出力が呼び出し元の stdout に返らず、scriptability を壊します。
+
+#### 対策要否
+- 必要です。
+
+#### 推奨対策
+- `copilot_should_use_tmux()` は少なくとも以下の条件を満たす場合のみ `true` にする。
+  - `stdin` が TTY
+  - `stdout` が TTY
+  - programmatic mode を示す Copilot 引数が無い
+  - テスト用強制フラグが無い限り、非対話シグナルを優先する
+
+#### 技術的実装案
+
+現状:
+
+```bash
+if [[ ! -t 0 ]]; then
+    return 1
+fi
+```
+
+修正案:
+
+```bash
+if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
+    return 0
+fi
+
+if [[ ! -t 0 || ! -t 1 ]]; then
+    return 1
+fi
+
+if copilot_requests_programmatic_mode "$@"; then
+    return 1
+fi
+
+return 0
+```
+
+補足:
+- テスト harness では stdout が TTY でないことが多く、外側 tmux テストが壊れやすいため、`SANDBOX_COPILOT_FORCE_TMUX` は引き続きテスト専用 escape hatch として維持するのが現実的です。
+- 本番経路では `stdout` も TTY 条件に含める方が、programmatic contract と整合します。
+
+#### 追加テスト案
+- `copilot_noninteractive_bypasses_tmux`
+  - stdout リダイレクトや command substitution を模したケースを追加する
+  - 例: `"$tmp_dir/host/sandbox" copilot ... >"$tmp_dir/out.txt"` を実行し、tmux ログが空であること
+- `copilot_noninteractive_preserves_exit_status`
+  - stdout 非 TTY 条件でも exit status が保持されること
+
+## 優先度評価
+
+### Review-01 の優先度
+- `P1` は妥当です。
+- 理由:
+  - 非対話経路を追加した意図そのものを崩す
+  - programmatic mode の代表用途に直撃する
+  - 修正範囲は比較的局所的
+
+### Review-02 の優先度
+- `P2` は妥当、ただし運用影響は大きめです。
+- 理由:
+  - stdout を消費する利用形態を壊す
+  - ただし stdin 非 TTYや `-p/-s` 指定では一部 already mitigated な経路があるため、Review-01 よりは一段落として扱う余地がある
+
+## 推奨対応方針
+
+### 最小で正しい修正
+1. 非対話経路の `docker compose exec` に `-T` を付ける
+2. `copilot_should_use_tmux()` を `stdin` と `stdout` の両方で判定する
+3. 既存の programmatic mode 判定は維持する
+4. 既存テストを更新し、stdout 非 TTY 条件でも tmux バイパスを確認する
+
+### 影響ファイル
+- `host/sandbox`
+- `tests/sandbox_cli.test.sh`
+- 必要なら `.spec-dock/current/design.md`
+- 必要なら `.spec-dock/current/plan.md`
+
+## まとめ
+- 2件ともレビューとして妥当です。
+- どちらも `sandbox copilot` の「scriptable である」という期待を守るための指摘です。
+- 対策は限定的で、既存設計を壊さずに修正可能です。
+- 次の修正では以下を実施するのが適切です。
+  - 非対話 `compose exec` に `-T` を追加
+  - tmux 利用判定に `stdout` 非 TTY も含める
+
+## 参照
+- Docker Docs: `docker compose exec`
+  - https://docs.docker.com/compose/reference/exec

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -1,79 +1,249 @@
 ---
 種別: 実装計画書
-機能ID: "<FEATURE_ID>"
-機能名: "<FEATURE_NAME>"
-関連Issue: ["<ISSUE_NUMBER_OR_URL>"]
-状態: "draft | approved"
-作成者: "<YOUR_NAME>"
-最終更新: "YYYY-MM-DD"
+機能ID: "FEATURE-COPILOT-CLI-INTEGRATION"
+機能名: "GitHub Copilot CLI を sandbox ツールチェーンへ統合する"
+関連Issue: []
+状態: "draft"
+作成者: "Codex"
+最終更新: "2026-03-19"
 依存: ["requirement.md", "design.md"]
 ---
 
-# <FEATURE_ID> <FEATURE_NAME> — 実装計画（TDD: Red → Green → Refactor）
+# FEATURE-COPILOT-CLI-INTEGRATION GitHub Copilot CLI を sandbox ツールチェーンへ統合する — 実装計画（TDD: Red → Green → Refactor）
 
 ## この計画で満たす要件ID (必須)
-- 対象AC: AC-001, AC-002, ...
-- 対象EC: EC-001, ...
-- 対象制約（該当があれば）: ...
+- 対象AC: AC-001, AC-002, AC-003, AC-004
+- 対象EC: EC-001, EC-002, EC-003, EC-004, EC-005
+- 対象制約（該当があれば）:
+  - `.agent-home` ベースの永続化設計を維持する
+  - 標準ディレクトリ `~/.copilot` を使う
+  - tmux ラッパーを追加する
 
 ## ステップ一覧（観測可能な振る舞い） (必須)
-- [ ] S01: ...
-- [ ] Sxx: ... (任意: 必要に応じて追加)
+- [ ] S01: Copilot CLI が共有 npm グローバルツール群へ追加され、verify 対象にも含まれる
+- [ ] S02: Copilot 標準ディレクトリ `~/.copilot` が `.agent-home/.copilot` から永続化される
+- [ ] S03: `sandbox copilot` が tmux 経由でコンテナ内 `copilot` を起動できる
+- [ ] S04: help とテストが Copilot 統合後の仕様を保証する
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
-- AC-___ → Sxx (任意: 必要に応じて追加)
-- EC-___ → Sxx (任意: 必要に応じて追加)
-- （任意）非交渉制約 → Sxx（どのステップで担保/検証するか）
+- AC-002 → S02
+- AC-003 → S03
+- AC-004 → S04
+- EC-001 → S03, S04
+- EC-002 → S04
+- EC-003 → S01, S04
+- EC-004 → S02
+- EC-005 → S03
+- 非交渉制約（標準ディレクトリ運用） → S02
+- 非交渉制約（tmux ラッパー） → S03
 
 ---
 
 ## 実装ステップ（各ステップは“観測可能な振る舞い”を1つ） (必須)
 
-### S01 — <観測可能な振る舞い> (必須)
-- 対象: AC-___ / EC-___
+### S01 — Copilot CLI が共有 npm グローバルツール群へ追加され、verify 対象にも含まれる (必須)
+- 対象: AC-001 / EC-003
 - 設計参照:
-  - 対象IF/API: IF-___ / API-___
-  - 対象テスト: `<test_file_path>::<test_name>`
+  - 対象IF/API: なし
+  - 対象テスト: `tests/sandbox_cli.test.sh::tools_update_runs_compose`、`tests/sandbox_cli.test.sh::package_json_lists_copilot_install_and_verify`
 - このステップで「追加しないこと（スコープ固定）」:
-  - ...
+  - `sandbox copilot` 本体はまだ追加しない
 
 #### update_plan（着手時に登録） (必須)
 - [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
 - 登録例:
-  - （調査）既存挙動/影響範囲の確認、設計参照の確認
-  - （Red）失敗するテストの追加/修正
-  - （Green）最小実装
-  - （Refactor）整理
-  - （品質ゲート）format/lint/test
+  - （調査）`package.json` と `tools update` フロー確認
+  - （Red）tools update/verify 仕様に関する失敗テスト確認
+  - （Green）`package.json` 更新
+  - （Refactor）文言・順序整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
   - （報告）`.spec-dock/current/report.md` 更新
   - （コミット）このステップの区切りでコミット
 
 #### 期待する振る舞い（テストケース） (必須)
-- Given: ...
-- When: ...
-- Then: ...
-- 観測点（UI/HTTP/DB/Log など）: ...
-- 追加/更新するテスト: `<test_file_path>::<test_name>`
+- Given: sandbox ツール更新フローが有効
+- When: `sandbox tools update` を実行する
+- Then: Copilot CLI を含む install-global が compose run で呼ばれ、`package.json` の `install-global` に `@github/copilot`、`verify` に `copilot --version` が含まれる
+- 観測点（UI/HTTP/DB/Log など）: compose stub ログ、`package.json`
+- 追加/更新するテスト: 既存 `tools_update_runs_compose` の非回帰確認、新規 `package_json_lists_copilot_install_and_verify`
 
 #### Red（失敗するテストを先に書く） (任意)
 - 期待する失敗:
-  - ...
+  - `package.json` に Copilot CLI が無く、verify 対象にも含まれない
 
 #### Green（最小実装） (任意)
 - 変更予定ファイル:
-  - Add: `<path/...>`
-  - Modify: `<path/...>`
+  - Modify: `package.json`
 - 追加する概念（このステップで導入する最小単位）:
-  - ...
+  - npm パッケージ `@github/copilot`
 - 実装方針（最小で。余計な最適化は禁止）:
-  - ...
+  - `dependencies`、`install-global`、`verify` の3点のみを揃えて更新する
 
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
-  - ...
+  - ツール一覧の順序と可読性を保つ
 - 変更対象:
-  - ...
+  - `package.json`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S02 — Copilot 標準ディレクトリ `~/.copilot` が `.agent-home/.copilot` から永続化される (必須)
+- 対象: AC-002 / EC-004
+- 設計参照:
+  - 対象IF/API: IF-001
+  - 対象テスト: `.agent-home` 作成系テスト
+- このステップで「追加しないこと（スコープ固定）」:
+  - Copilot 固有の cache や追加ディレクトリを推測で増やさない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）既存 `.agent-home` mount / Dockerfile 作成先確認
+  - （Red）`.agent-home` 作成テストの失敗確認
+  - （Green）`Dockerfile`、`docker-compose.yml`、`host/sandbox` 更新
+  - （Refactor）mount 一覧の整列
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: 初回起動で `.agent-home/.copilot` が存在しない
+- When: `sandbox up` または `sandbox build` の前処理を実行する
+- Then: `.agent-home/.copilot` が作成され、コンテナ標準ディレクトリ `/home/node/.copilot` へ mount される
+- 観測点（UI/HTTP/DB/Log など）: `.agent-home` 配下、`docker-compose.yml`、`Dockerfile`
+- 追加/更新するテスト: `.agent-home` 作成系テスト
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - `.agent-home/.copilot` が作成されない
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `Dockerfile`
+  - Modify: `docker-compose.yml`
+- 追加する概念（このステップで導入する最小単位）:
+  - `.agent-home/.copilot` と `/home/node/.copilot` の対応
+- 実装方針（最小で。余計な最適化は禁止）:
+  - 既存ツールと同じく標準ディレクトリ全体を 1 mount で扱う
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - mount 一覧とディレクトリ作成一覧の整合
+- 変更対象:
+  - `host/sandbox`, `Dockerfile`, `docker-compose.yml`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S03 — `sandbox copilot` が tmux 経由でコンテナ内 `copilot` を起動できる (必須)
+- 対象: AC-003 / EC-001
+- 設計参照:
+  - 対象IF/API: IF-002, IF-003, IF-005
+  - 対象テスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`, `copilot_errors_when_tmux_missing`
+- このステップで「追加しないこと（スコープ固定）」:
+  - Copilot 独自の権限モード切替や Trust 制御は追加しない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）`sandbox codex` の tmux/compose 実装確認
+  - （Red）Copilot サブコマンドの失敗テスト追加
+  - （Green）`host/sandbox` に `sandbox copilot` 実装
+  - （Refactor）共通化できる最小範囲を整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: Docker と tmux が使え、`sandbox copilot [options] -- [copilot args...]` の契約がある
+- When: `sandbox copilot --mount-root <root> --workdir <subdir> -- --help` を実行する
+- Then: 外側は tmux セッションを張り、内側は compose up 後に `copilot --help` を `container_workdir` で実行する
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose stub ログ
+- 追加/更新するテスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`, `copilot_errors_when_tmux_missing`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - `copilot` サブコマンドが未定義
+  - tmux セッション名や compose exec が期待通りにならない
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `run_compose_exec_copilot`
+  - `compute_copilot_session_name`
+  - `split_copilot_args`
+- 実装方針（最小で。余計な最適化は禁止）:
+  - `sandbox codex` の tmux ラッパーを参考にしつつ、Copilot 固有ロジックは持たず単純に `copilot` 実行へ絞る
+  - `--` より後ろの引数は無加工で `copilot` に渡す
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - Codex/Copilot 間で重複する tmux 分岐を安全に整理する
+- 変更対象:
+  - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S04 — help とテストが Copilot 統合後の仕様を保証する (必須)
+- 対象: AC-004 / EC-002 / EC-003
+- 設計参照:
+  - 対象IF/API: IF-004
+  - 対象テスト: help 系テスト一式
+- このステップで「追加しないこと（スコープ固定）」:
+  - ドキュメントサイトや README の大規模更新はしない
+  - 起動フロー本体や `--` pass-through 実装はここで広げない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）既存 help 文面の構成確認
+  - （Red）help 期待値テスト追加
+  - （Green）help 文面更新、テスト調整
+  - （Refactor）文言統一
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: 利用者が help を見る
+- When: `sandbox --help`、`sandbox tools --help`、`sandbox copilot --help` を実行する
+- Then: Copilot CLI の存在と使い方が副作用なしで分かり、`sandbox copilot --help` は sandbox help、`sandbox copilot -- --help` は Copilot help として役割分担が明確である
+- 観測点（UI/HTTP/DB/Log など）: stdout、ファイル副作用なし
+- 追加/更新するテスト: `help_top_level`, `help_subcommand`, `help_copilot_mentions_tmux`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - help に Copilot が出ない
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `copilot` help 文言
+- 実装方針（最小で。余計な最適化は禁止）:
+  - 既存 help パターンに Copilot を追加し、副作用なしテストで担保する
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - help 文面を CLI 一覧として自然に保つ
+- 変更対象:
+  - `host/sandbox`
 
 #### ステップ末尾（省略しない） (必須)
 - [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
@@ -83,32 +253,18 @@
 
 ---
 
-### Sxx — <追加の観測可能な振る舞い> (任意)
-- （上の S01 と同じ構成で記載する。update_plan / 期待する振る舞い / ステップ末尾 は省略しない）
-  ...
-
----
-
 ## 未確定事項（TBD） (必須)
-- Q-001:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: S__ / AC-__ / EC-__ / `design.md` / ...
-- Q-002:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: ...
+- 該当なし
+
+## 合意済み決定事項 (任意)
+- D-001: `sandbox copilot` の CLI 契約は `sandbox copilot [options] -- [copilot args...]`
+- D-002: `--` より後ろの引数は `copilot` へ pass-through する
+- D-003: `verify` の Copilot 検証は `copilot --version` に固定する
 
 ## 完了条件（Definition of Done） (必須)
 - 対象AC/ECがすべて満たされ、テストで保証されている
-- MUST NOT / OUT OF SCOPE を破っていない（追加機能を入れていない）
-- 品質ゲート（フォーマット/リント/テストのうち該当するもの）が満たされている
+- MUST NOT / OUT OF SCOPE を破っていない
+- 品質ゲート（`bash tests/sandbox_cli.test.sh`、必要に応じて `npm run verify`）が満たされている
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -27,6 +27,7 @@
 - [ ] S05: Copilot の非対話利用では tmux をバイパスし、終了コードを保持する
 - [ ] S06: Copilot の非対話利用では `docker compose exec -T` を使い、stdout リダイレクト時も tmux を使わない
 - [ ] S07: Copilot の対話/非対話モード境界を明示し、対話モードの TTY 不足は明示エラー、`-p` / `--prompt` には承認オーバーライドを必須化する
+- [ ] S08: Copilot の headless invocation を公式仕様に合わせ、`--allow-all` / `--yolo` と `help` / `version` / stdin オプション入力を direct exec で扱えるようにする
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -42,11 +43,13 @@
 - EC-005 → S05
 - EC-005 → S06
 - EC-005 → S07
+- EC-005 → S08
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
 - 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
 - 非交渉制約（非対話時は TTY を割り当てず、stdout 消費側へ出力を返す） → S06
 - 非交渉制約（曖昧なモード切替をせず、前提不足は明示エラーにする） → S07
+- 非交渉制約（公式の headless entry point を wrapper が阻害しない） → S08
 
 ---
 
@@ -158,7 +161,7 @@
 - 対象: AC-003 / EC-001
 - 設計参照:
   - 対象IF/API: IF-002, IF-003, IF-005
-  - 対象テスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`, `copilot_errors_when_tmux_missing`
+  - 対象テスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_errors_when_tmux_missing`
 - このステップで「追加しないこと（スコープ固定）」:
   - Copilot 独自の権限モード切替や Trust 制御は追加しない
 
@@ -178,7 +181,7 @@
 - When: `sandbox copilot --mount-root <root> --workdir <subdir> -- --help` を実行する
 - Then: 外側は tmux セッションを張り、内側は compose up 後に `copilot --help` を `container_workdir` で実行する
 - 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose stub ログ
-- 追加/更新するテスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_is_passed_to_copilot`, `copilot_errors_when_tmux_missing`
+- 追加/更新するテスト: `copilot_outer_uses_tmux_and_session_name`, `copilot_inner_runs_copilot_and_returns_to_zsh`, `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_errors_when_tmux_missing`
 
 #### Red（失敗するテストを先に書く） (任意)
 - 期待する失敗:
@@ -322,7 +325,7 @@
 - 対象: AC-003 / EC-005
 - 設計参照:
   - 対象IF/API: IF-002, IF-007
-  - 対象テスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+  - 対象テスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_errors_for_interactive_mode`, `copilot_noninteractive_preserves_exit_status`
 - このステップで「追加しないこと（スコープ固定）」:
   - Copilot の引数体系や programmatic mode 判定条件自体は広げない
   - Codex サブコマンドの exec/TTY 仕様は変更しない
@@ -343,7 +346,7 @@
 - When: `printf ... | sandbox copilot ...` または `sandbox copilot ... > out.txt` のような非対話利用を行う
 - Then: tmux を使わず、`docker compose exec -T` で Copilot を実行し、呼び出し元の stdout/stderr/exit code を保持する
 - 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログの `-T`、出力先、終了コード
-- 追加/更新するテスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+- 追加/更新するテスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_errors_for_interactive_mode`, `copilot_noninteractive_preserves_exit_status`
 
 #### Red（失敗するテストを先に書く） (任意)
 - 期待する失敗:
@@ -419,6 +422,62 @@
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
   - Copilot 呼び出し前検証と tmux 判定の責務を分けて読みやすくする
+- 変更対象:
+  - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S08 — Copilot の headless invocation を公式仕様に合わせ、`--allow-all` / `--yolo` と `help` / `version` / stdin オプション入力を direct exec で扱えるようにする (必須)
+- 対象: AC-003 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-006, IF-007, IF-008, IF-009, IF-010
+  - 対象テスト: `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`, `copilot_programmatic_accepts_allow_all_aliases`, `copilot_stdin_option_stream_uses_direct_exec`
+- このステップで「追加しないこと（スコープ固定）」:
+  - wrapper 側で stdin の中身を完全解釈する独自 parser は実装しない
+  - Copilot 本体の approval semantics を置き換えない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）最新レビューと現行 headless 判定の差分確認
+  - （Red）`--allow-all` / `--yolo`、help/version、stdin オプション入力の失敗テスト追加
+  - （Green）`host/sandbox` に headless invocation 判定を追加
+  - （Refactor）programmatic 判定と headless 判定の責務分離
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: `sandbox copilot [options] -- [copilot args...]` をスクリプトや CI から呼び出す
+- When: `sandbox copilot -- --help` / `sandbox copilot -- --version` / `sandbox copilot -- -p "fix" --allow-all` / `printf '%s\n' --version | sandbox copilot` のような headless invocation を行う
+- Then: これらは tmux を使わず `docker compose exec -T` の直接実行へ進み、`--allow-all` と `--yolo` は承認オーバーライドとして受理される
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログ、終了コード
+- 追加/更新するテスト: `copilot_help_flag_after_double_dash_uses_direct_exec`, `copilot_version_flag_uses_direct_exec`, `copilot_programmatic_accepts_allow_all_aliases`, `copilot_stdin_option_stream_uses_direct_exec`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - `--allow-all` / `--yolo` が approval override として認識されない
+  - `--help` / `--version` が tmux 対話経路へ入る
+  - stdin からのオプション入力が TTY エラーで止まる
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `copilot_requests_headless_mode`
+  - `--allow-all` / `--yolo` の approval alias
+- 実装方針（最小で。余計な最適化は禁止）:
+  - `-p` / `--prompt` は programmatic 判定のまま維持しつつ、tmux 回避条件は `help` / `version` / stdin オプション入力を含む headless invocation に広げる
+  - stdin 非 TTYかつ引数空のケースは wrapper が中身を解釈せず、本体に直接渡す
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - headless invocation 判定を対話判定から切り離して読みやすくする
 - 変更対象:
   - `host/sandbox`
 

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -28,6 +28,7 @@
 - [ ] S06: Copilot の非対話利用では `docker compose exec -T` を使い、stdout リダイレクト時も tmux を使わない
 - [ ] S07: Copilot の対話/非対話モード境界を明示し、対話モードの TTY 不足は明示エラー、`-p` / `--prompt` には承認オーバーライドを必須化する
 - [ ] S08: Copilot の headless invocation を公式仕様に合わせ、`--allow-all` / `--yolo` と `help` / `version` / stdin オプション入力を direct exec で扱えるようにする
+- [ ] S09: Copilot の公式 headless サブコマンドと tmux セッション名の一意性を保証し、擬似TTYテストを Linux/macOS 両対応にする
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -44,12 +45,14 @@
 - EC-005 → S06
 - EC-005 → S07
 - EC-005 → S08
+- EC-005 → S09
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
 - 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
 - 非交渉制約（非対話時は TTY を割り当てず、stdout 消費側へ出力を返す） → S06
 - 非交渉制約（曖昧なモード切替をせず、前提不足は明示エラーにする） → S07
 - 非交渉制約（公式の headless entry point を wrapper が阻害しない） → S08
+- 非交渉制約（ワークスペース間で tmux セッションが衝突しない） → S09
 
 ---
 
@@ -480,6 +483,65 @@
   - headless invocation 判定を対話判定から切り離して読みやすくする
 - 変更対象:
   - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S09 — Copilot の公式 headless サブコマンドと tmux セッション名の一意性を保証し、擬似TTYテストを Linux/macOS 両対応にする (必須)
+- 対象: AC-003 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-003, IF-007, IF-010
+  - 対象テスト: `copilot_init_uses_direct_exec`, `copilot_session_name_disambiguates_same_basename_paths`, `copilot_redirected_stdout_errors_for_interactive_mode`
+- このステップで「追加しないこと（スコープ固定）」:
+  - Copilot の公式サブコマンド以外を推測で headless 扱いしない
+  - tmux セッション名変更で Compose container 名や project 名の規則までは変えない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）レビュー指摘と現行 headless 判定/セッション名生成/擬似TTYテストの差分確認
+  - （Red）`init` direct exec、同 basename 別パス衝突、Linux util-linux `script` 互換の失敗テスト追加
+  - （Green）`host/sandbox` の headless サブコマンド判定と session 名生成を修正
+  - （Refactor）test helper を BSD/util-linux 両対応に整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: basename が同じ別ワークスペースや、`sandbox copilot -- init` のような公式サブコマンド実行がある
+- When: `sandbox copilot -- init` を非TTY環境から呼ぶ、または basename が同じ別ディレクトリから `sandbox copilot` を呼ぶ
+- Then: `init` は tmux を使わず direct exec され、tmux セッション名はフルパス差分を反映して衝突しない
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログ、セッション名文字列、終了コード
+- 追加/更新するテスト: `copilot_init_uses_direct_exec`, `copilot_session_name_disambiguates_same_basename_paths`, `copilot_redirected_stdout_errors_for_interactive_mode`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - `init` が TTY 必須エラーになる
+  - basename が同じ別ディレクトリで同じ tmux セッション名になる
+  - Linux util-linux `script` で擬似TTYテストが起動しない
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - 公式 headless サブコマンド判定
+  - hash 付き Copilot session 名
+  - `script` 実行 helper
+- 実装方針（最小で。余計な最適化は禁止）:
+  - headless 判定には `init` / `update` / `plugin` / `login` / `logout` を追加する
+  - session 名は basename に `CALLER_PWD` の hash を足して一意化する
+  - 擬似TTYテストは `script -c` が使える環境ではそれを使い、使えない環境では BSD 形式へフォールバックする
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - headless サブコマンド判定と test helper を読みやすく保つ
+- 変更対象:
+  - `host/sandbox`
+  - `tests/sandbox_cli.test.sh`
 
 #### ステップ末尾（省略しない） (必須)
 - [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -29,6 +29,7 @@
 - [ ] S07: Copilot の対話/非対話モード境界を明示し、対話モードの TTY 不足は明示エラー、`-p` / `--prompt` には承認オーバーライドを必須化する
 - [ ] S08: Copilot の headless invocation を公式仕様に合わせ、`--allow-all` / `--yolo` と `help` / `version` / stdin オプション入力を direct exec で扱えるようにする
 - [ ] S09: Copilot の公式 headless サブコマンドと tmux セッション名の一意性を保証し、擬似TTYテストを Linux/macOS 両対応にする
+- [ ] S10: Copilot の ACP 起動を headless invocation として許可し、擬似TTY helper が Linux で子プロセス終了コードを返すようにする
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -46,6 +47,7 @@
 - EC-005 → S07
 - EC-005 → S08
 - EC-005 → S09
+- EC-005 → S10
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
 - 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
@@ -53,6 +55,7 @@
 - 非交渉制約（曖昧なモード切替をせず、前提不足は明示エラーにする） → S07
 - 非交渉制約（公式の headless entry point を wrapper が阻害しない） → S08
 - 非交渉制約（ワークスペース間で tmux セッションが衝突しない） → S09
+- 非交渉制約（ACP/擬似TTY経由でも正しい stdio と終了コードを観測できる） → S10
 
 ---
 
@@ -539,6 +542,62 @@
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
   - headless サブコマンド判定と test helper を読みやすく保つ
+- 変更対象:
+  - `host/sandbox`
+  - `tests/sandbox_cli.test.sh`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S10 — Copilot の ACP 起動を headless invocation として許可し、擬似TTY helper が Linux で子プロセス終了コードを返すようにする (必須)
+- 対象: AC-003 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-007, IF-010
+  - 対象テスト: `copilot_acp_uses_direct_exec`, `copilot_redirected_stdout_errors_for_interactive_mode`
+- このステップで「追加しないこと（スコープ固定）」:
+  - ACP の引数体系や通信仕様自体は wrapper 側で解釈しない
+  - `run_in_pseudo_tty` を本格的な cross-platform ライブラリ化はしない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）`--acp` と util-linux `script --return` の差分確認
+  - （Red）ACP direct exec と pseudo tty helper の exit status 伝播テスト追加
+  - （Green）`host/sandbox` の headless 判定と `tests/sandbox_cli.test.sh` helper を修正
+  - （Refactor）headless フラグ一覧と helper 分岐を整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: ACP client や stdout リダイレクト付きの対話テストが Linux/macOS の両方で動く必要がある
+- When: `sandbox copilot -- --acp` を呼ぶ、または擬似TTY経由で wrapper の non-zero を観測する
+- Then: `--acp` は tmux を使わず direct exec され、`run_in_pseudo_tty` は util-linux でも子プロセスの終了コードを返す
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログ、終了コード
+- 追加/更新するテスト: `copilot_acp_uses_direct_exec`, `copilot_redirected_stdout_errors_for_interactive_mode`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - `--acp` が TTY エラーまたは tmux 経路へ入る
+  - util-linux `script` 経由で子プロセスの non-zero が観測できない
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `--acp` headless flag
+  - util-linux `script -e`
+- 実装方針（最小で。余計な最適化は禁止）:
+  - `copilot_requests_headless_mode` に `--acp` を追加する
+  - `run_in_pseudo_tty` は util-linux 経路で `-e` を付け、BSD フォールバックは維持する
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - headless flag と pseudo tty helper の責務を明確に保つ
 - 変更対象:
   - `host/sandbox`
   - `tests/sandbox_cli.test.sh`

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -26,6 +26,7 @@
 - [ ] S04: help とテストが Copilot 統合後の仕様を保証する
 - [ ] S05: Copilot の非対話利用では tmux をバイパスし、終了コードを保持する
 - [ ] S06: Copilot の非対話利用では `docker compose exec -T` を使い、stdout リダイレクト時も tmux を使わない
+- [ ] S07: Copilot の対話/非対話モード境界を明示し、対話モードの TTY 不足は明示エラー、`-p` / `--prompt` には承認オーバーライドを必須化する
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -40,10 +41,12 @@
 - EC-001 → S05
 - EC-005 → S05
 - EC-005 → S06
+- EC-005 → S07
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
 - 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
 - 非交渉制約（非対話時は TTY を割り当てず、stdout 消費側へ出力を返す） → S06
+- 非交渉制約（曖昧なモード切替をせず、前提不足は明示エラーにする） → S07
 
 ---
 
@@ -361,6 +364,61 @@
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
   - 非対話経路の契約を条件レベルではっきりさせる
+- 変更対象:
+  - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S07 — Copilot の対話/非対話モード境界を明示し、対話モードの TTY 不足は明示エラー、`-p` / `--prompt` には承認オーバーライドを必須化する (必須)
+- 対象: AC-003 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-006, IF-007, IF-008, IF-009
+  - 対象テスト: `copilot_programmatic_requires_approval_override`, `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_errors_for_interactive_mode`
+- このステップで「追加しないこと（スコープ固定）」:
+  - Copilot の承認仕様をラッパー側で独自実装しない
+  - `sandbox codex` など他サブコマンドの TTY 判定は変更しない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）最新 PR レビューと現行 S06 実装の差分確認
+  - （Red）TTY 不足時の暗黙モード変更と承認不足 `-p` 実行の失敗テスト追加
+  - （Green）`host/sandbox` に Copilot 呼び出し前検証を追加
+  - （Refactor）programmatic 判定と承認判定の責務分離
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: `sandbox copilot [options] -- [copilot args...]` を対話シェル、パイプ、リダイレクト、CI から呼び出す
+- When: `sandbox copilot > out.txt` のように対話モードなのに TTY が不足している、または `sandbox copilot -- -- -p "fix"` のように承認オーバーライド無しで programmatic mode を要求する
+- Then: 対話モードは明示エラーで止まり、programmatic mode は `--allow-all-tools` / `--allow-tool ...` / `COPILOT_ALLOW_ALL` がある場合にのみ `exec -T` 経路へ進む
+- 観測点（UI/HTTP/DB/Log など）: stderr のエラーメッセージ、tmux stub ログ、compose exec ログ、終了コード
+- 追加/更新するテスト: `copilot_programmatic_requires_approval_override`, `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_errors_for_interactive_mode`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - 対話モードが stdout リダイレクト時に非対話経路へ暗黙変更される
+  - `-p` / `--prompt` が承認オーバーライド無しでも実行される
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `copilot_has_approval_override`
+  - `validate_copilot_invocation`
+- 実装方針（最小で。余計な最適化は禁止）:
+  - `-p` / `--prompt` を programmatic mode として扱い、承認オーバーライドの有無を先に検証する
+  - programmatic mode でない場合は、stdin と stdout の両方が TTY でない限り明示エラーにする
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - Copilot 呼び出し前検証と tmux 判定の責務を分けて読みやすくする
 - 変更対象:
   - `host/sandbox`
 

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -25,6 +25,7 @@
 - [ ] S03: `sandbox copilot` が tmux 経由でコンテナ内 `copilot` を起動できる
 - [ ] S04: help とテストが Copilot 統合後の仕様を保証する
 - [ ] S05: Copilot の非対話利用では tmux をバイパスし、終了コードを保持する
+- [ ] S06: Copilot の非対話利用では `docker compose exec -T` を使い、stdout リダイレクト時も tmux を使わない
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -38,9 +39,11 @@
 - EC-005 → S03
 - EC-001 → S05
 - EC-005 → S05
+- EC-005 → S06
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
 - 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
+- 非交渉制約（非対話時は TTY を割り当てず、stdout 消費側へ出力を返す） → S06
 
 ---
 
@@ -303,6 +306,61 @@
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
   - Copilot の対話/非対話フローを読みやすく分離する
+- 変更対象:
+  - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S06 — Copilot の非対話利用では `docker compose exec -T` を使い、stdout リダイレクト時も tmux を使わない (必須)
+- 対象: AC-003 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-002, IF-007
+  - 対象テスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+- このステップで「追加しないこと（スコープ固定）」:
+  - Copilot の引数体系や programmatic mode 判定条件自体は広げない
+  - Codex サブコマンドの exec/TTY 仕様は変更しない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）PR レビュー指摘と現在の S05 実装との差分確認
+  - （Red）`-T` 未付与と stdout リダイレクト時 tmux 使用の失敗テスト追加
+  - （Green）`host/sandbox` の Copilot 非対話 exec と tmux 判定を修正
+  - （Refactor）対話/非対話経路の条件整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: `sandbox copilot [options] -- [copilot args...]` を対話シェルやスクリプトから呼び出す
+- When: `printf ... | sandbox copilot ...` または `sandbox copilot ... > out.txt` のような非対話利用を行う
+- Then: tmux を使わず、`docker compose exec -T` で Copilot を実行し、呼び出し元の stdout/stderr/exit code を保持する
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログの `-T`、出力先、終了コード
+- 追加/更新するテスト: `copilot_noninteractive_bypasses_tmux`, `copilot_redirected_stdout_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - 非対話経路でも `docker compose exec` に `-T` が付かない
+  - stdout リダイレクト時に tmux セッションへ入ってしまう
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `stdout` 非 TTY を含む tmux 判定
+  - Copilot 非対話 exec の `-T`
+- 実装方針（最小で。余計な最適化は禁止）:
+  - `copilot_should_use_tmux` は stdin と stdout の両方が TTY のときだけ true にする
+  - 非対話経路では常に `docker compose exec -T` を使う
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - 非対話経路の契約を条件レベルではっきりさせる
 - 変更対象:
   - `host/sandbox`
 

--- a/.spec-dock/current/plan.md
+++ b/.spec-dock/current/plan.md
@@ -24,6 +24,7 @@
 - [ ] S02: Copilot 標準ディレクトリ `~/.copilot` が `.agent-home/.copilot` から永続化される
 - [ ] S03: `sandbox copilot` が tmux 経由でコンテナ内 `copilot` を起動できる
 - [ ] S04: help とテストが Copilot 統合後の仕様を保証する
+- [ ] S05: Copilot の非対話利用では tmux をバイパスし、終了コードを保持する
 
 ### 要件 ↔ ステップ対応表 (必須)
 - AC-001 → S01
@@ -35,8 +36,11 @@
 - EC-003 → S01, S04
 - EC-004 → S02
 - EC-005 → S03
+- EC-001 → S05
+- EC-005 → S05
 - 非交渉制約（標準ディレクトリ運用） → S02
 - 非交渉制約（tmux ラッパー） → S03
+- 非交渉制約（非対話時は標準入出力と終了コードを保持） → S05
 
 ---
 
@@ -242,6 +246,63 @@
 #### Refactor（振る舞い不変で整理） (任意)
 - 目的:
   - help 文面を CLI 一覧として自然に保つ
+- 変更対象:
+  - `host/sandbox`
+
+#### ステップ末尾（省略しない） (必須)
+- [ ] 期待するテスト（必要ならフォーマット/リンタ）を実行し、成功した
+- [ ] `.spec-dock/current/report.md` に実行コマンド/結果/変更ファイルを記録した
+- [ ] `update_plan` を更新し、このステップの作業ステップを完了にした
+- [ ] コミットした（エージェント）
+
+### S05 — Copilot の非対話利用では tmux をバイパスし、終了コードを保持する (必須)
+- 対象: AC-003 / EC-001 / EC-005
+- 設計参照:
+  - 対象IF/API: IF-002, IF-006, IF-007
+  - 対象テスト: `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+- このステップで「追加しないこと（スコープ固定）」:
+  - Codex サブコマンドの tmux 仕様は変更しない
+  - Copilot 固有の引数バリデーションや禁止引数制御は追加しない
+
+#### update_plan（着手時に登録） (必須)
+- [ ] `update_plan` に、このステップの作業ステップ（調査/Red/Green/Refactor/品質ゲート/報告/コミット）を登録した
+- 登録例:
+  - （調査）PR レビュー指摘と現行 `sandbox copilot` 実装差分の確認
+  - （Red）非対話バイパスと終了コード保持の失敗テスト追加
+  - （Green）`host/sandbox` の Copilot 実行分岐を修正
+  - （Refactor）対話/非対話の責務を整理
+  - （品質ゲート）`bash tests/sandbox_cli.test.sh`
+  - （報告）`.spec-dock/current/report.md` 更新
+  - （コミット）このステップの区切りでコミット
+
+#### 期待する振る舞い（テストケース） (必須)
+- Given: `sandbox copilot [options] -- [copilot args...]` が使え、標準入出力が非 TTY であるか、programmatic mode フラグが指定されている
+- When: `echo prompt | sandbox copilot --mount-root <root> --workdir <dir> -- -p test -s` のような非対話利用を行う
+- Then: tmux を経由せずにコンテナ内 `copilot` を直接実行し、Copilot の終了コードをそのまま返す
+- 観測点（UI/HTTP/DB/Log など）: tmux stub ログが空であること、compose exec ログ、終了コード
+- 追加/更新するテスト: `copilot_noninteractive_bypasses_tmux`, `copilot_noninteractive_preserves_exit_status`
+
+#### Red（失敗するテストを先に書く） (任意)
+- 期待する失敗:
+  - 非対話実行でも tmux セッションへ入ってしまう
+  - Copilot 失敗時に終了コードが 0 にマスクされる
+
+#### Green（最小実装） (任意)
+- 変更予定ファイル:
+  - Modify: `host/sandbox`
+  - Modify: `tests/sandbox_cli.test.sh`
+- 追加する概念（このステップで導入する最小単位）:
+  - `copilot_requests_programmatic_mode`
+  - `copilot_should_use_tmux`
+  - 対話/非対話で分岐する Copilot 実行ラッパー
+- 実装方針（最小で。余計な最適化は禁止）:
+  - stdin/stdout の TTY 状態と `copilot` 引数を見て tmux 利用要否を判定する
+  - 対話実行では成功時のみ zsh に戻し、失敗時は Copilot の終了コードを返す
+  - 非対話実行では zsh へ遷移せず、Copilot の終了コードをそのまま返す
+
+#### Refactor（振る舞い不変で整理） (任意)
+- 目的:
+  - Copilot の対話/非対話フローを読みやすく分離する
 - 変更対象:
   - `host/sandbox`
 

--- a/.spec-dock/current/report.md
+++ b/.spec-dock/current/report.md
@@ -14,7 +14,7 @@
 ## 実装サマリー (任意)
 - Copilot wrapper の headless 判定を公式サブコマンドまで拡張し、`init` などを tmux なしで直接実行できるようにした。
 - Copilot の tmux セッション名に `CALLER_PWD` 由来の hash を加えて、basename が同じ別ワークスペースで衝突しないようにした。
-- 擬似TTYテストは `script -c` 対応環境ではその形式を使い、非対応環境では BSD 形式へフォールバックするようにした。
+- 擬似TTYテストは `script -c` 対応環境では `-e` 付きで子プロセスの終了コードを返し、非対応環境では BSD 形式へフォールバックするようにした。
 
 ## 実装記録（セッションログ） (必須)
 
@@ -52,6 +52,40 @@ bash tests/sandbox_cli.test.sh
 
 #### メモ
 - `compute_codex_session_name()` にも basename 衝突の余地は残るが、今回の修正対象は Copilot レビュー対応に限定した。
+
+### 2026-03-19 22:45 - 22:55
+
+#### 対象
+- Step: S10
+- AC/EC: AC-003, EC-005
+
+#### 実施内容
+- `design.md` に `--acp` を headless invocation として追補した。
+- `plan.md` に S10 を追加し、ACP direct exec と util-linux `script -e` の終了コード伝播を新しい修正ステップとして定義した。
+- `host/sandbox` の `copilot_requests_headless_mode()` に `--acp` を追加した。
+- `tests/sandbox_cli.test.sh` の `run_in_pseudo_tty()` に util-linux 向け `-e` を追加し、`copilot_acp_uses_direct_exec` テストを追加した。
+
+#### 実行コマンド / 結果
+```bash
+bash -n host/sandbox tests/sandbox_cli.test.sh
+# success
+
+bash tests/sandbox_cli.test.sh
+# success
+```
+
+#### 変更したファイル
+- `.spec-dock/current/design.md` - S10 の設計追補
+- `.spec-dock/current/plan.md` - S10 の追加
+- `.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-05.md` - 最新レビュー分析
+- `host/sandbox` - `--acp` を headless 判定へ追加
+- `tests/sandbox_cli.test.sh` - util-linux `script -e` と ACP direct exec テストを追加
+
+#### コミット
+- 未実施
+
+#### メモ
+- `run_in_pseudo_tty()` は util-linux 経路で `-e` を付けるが、BSD 形式フォールバックはそのまま維持した。
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/.spec-dock/current/report.md
+++ b/.spec-dock/current/report.md
@@ -1,71 +1,57 @@
 ---
 種別: 実装報告書
-機能ID: "<FEATURE_ID>"
-機能名: "<FEATURE_NAME>"
-関連Issue: ["<ISSUE_NUMBER_OR_URL>"]
-状態: "draft | approved"
-作成者: "<YOUR_NAME>"
-最終更新: "YYYY-MM-DD"
+機能ID: "FEATURE-COPILOT-CLI-INTEGRATION"
+機能名: "GitHub Copilot CLI を sandbox ツールチェーンへ統合する"
+関連Issue: ["10"]
+状態: "draft"
+作成者: "Codex"
+最終更新: "2026-03-19"
 依存: ["requirement.md", "design.md", "plan.md"]
 ---
 
-# <FEATURE_ID> <FEATURE_NAME> — 実装報告（LOG）
+# FEATURE-COPILOT-CLI-INTEGRATION GitHub Copilot CLI を sandbox ツールチェーンへ統合する — 実装報告（LOG）
 
 ## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+- Copilot wrapper の headless 判定を公式サブコマンドまで拡張し、`init` などを tmux なしで直接実行できるようにした。
+- Copilot の tmux セッション名に `CALLER_PWD` 由来の hash を加えて、basename が同じ別ワークスペースで衝突しないようにした。
+- 擬似TTYテストは `script -c` 対応環境ではその形式を使い、非対応環境では BSD 形式へフォールバックするようにした。
 
 ## 実装記録（セッションログ） (必須)
 
-### YYYY-MM-DD HH:MM - HH:MM
+### 2026-03-19 22:20 - 22:45
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
+- Step: S09
+- AC/EC: AC-003, EC-005
 
 #### 実施内容
-- ...
+- `design.md` に公式 headless サブコマンド、Copilot session 名一意化、テスト方針を追補した。
+- `plan.md` に S09 を追加し、公式サブコマンド direct exec、session 名衝突回避、擬似TTYテスト移植性を新しい修正ステップとして定義した。
+- `host/sandbox` の `copilot_requests_headless_mode()` を拡張し、`init` / `update` / `plugin` / `login` / `logout` を headless 扱いにした。
+- `host/sandbox` の `compute_copilot_session_name()` を hash 付きに変更した。
+- `tests/sandbox_cli.test.sh` に session 名一意性、`init` direct exec、BSD/util-linux 両対応の `script` helper を追加した。
 
 #### 実行コマンド / 結果
 ```bash
-<command>
+bash -n host/sandbox tests/sandbox_cli.test.sh
+# success
 
-<result>
+bash tests/sandbox_cli.test.sh
+# success
 ```
 
 #### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
+- `.spec-dock/current/design.md` - S09 の設計追補
+- `.spec-dock/current/plan.md` - S09 の追加
+- `.spec-dock/current/discussions/2026-03-19-copilot-review-analysis-04.md` - 最新レビュー分析
+- `host/sandbox` - headless サブコマンド判定と Copilot session 名の修正
+- `tests/sandbox_cli.test.sh` - session 名一意性、`init` direct exec、擬似TTY helper のテスト追加
 
 #### コミット
-- <hash> <message>
+- 未実施
 
 #### メモ
-- ...
-
----
-
-### YYYY-MM-DD HH:MM - HH:MM
-
-#### 対象
-- Step: ...
-- AC/EC: ...
-
-#### 実施内容
-- ...
-
----
-
-## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
-
-## 学んだこと (任意)
-- ...
-- ...
-
-## 今後の推奨事項 (任意)
-- ...
-- ...
+- `compute_codex_session_name()` にも basename 衝突の余地は残るが、今回の修正対象は Copilot レビュー対応に限定した。
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/.spec-dock/current/requirement.md
+++ b/.spec-dock/current/requirement.md
@@ -1,135 +1,214 @@
 ---
 種別: 要件定義書
-機能ID: "<FEATURE_ID>"
-機能名: "<FEATURE_NAME>"
-関連Issue: ["<ISSUE_NUMBER_OR_URL>"]
-状態: "draft | approved"
-作成者: "<YOUR_NAME>"
-最終更新: "YYYY-MM-DD"
+機能ID: "FEATURE-COPILOT-CLI-INTEGRATION"
+機能名: "GitHub Copilot CLI を sandbox ツールチェーンへ統合する"
+関連Issue: []
+状態: "draft"
+作成者: "Codex"
+最終更新: "2026-03-19"
 ---
 
-# <FEATURE_ID> <FEATURE_NAME> — 要件定義（WHAT / WHY）
+# FEATURE-COPILOT-CLI-INTEGRATION GitHub Copilot CLI を sandbox ツールチェーンへ統合する — 要件定義（WHAT / WHY）
 
 ## 目的（ユーザーに見える成果 / To-Be） (必須)
-- （1〜3行）この機能でユーザーが「何をできるようになるか」を書く。
+- このツールの Docker サンドボックス上で GitHub Copilot CLI を既存の Codex CLI / Claude Code / Gemini CLI / OpenCode と同列に利用できるようにする。
+- GitHub Copilot CLI が生成・利用するユーザー設定や関連ファイルを、ホスト側の `.agent-home` 配下から標準ディレクトリへ mount して永続化できるようにする。
+- 既存の `sandbox codex` と同系統の操作感で、`sandbox copilot` から tmux 経由で Copilot CLI を起動できるようにする。
 
 ## 背景・現状（As-Is / 調査メモ） (必須)
 - 現状の挙動（事実）:
-  - ...
+  - このリポジトリは Docker コンテナ `agent-sandbox` を起動し、作業対象ディレクトリと `.agent-home` 配下のエージェント設定ディレクトリを bind mount する構成である。
+  - 現時点で mount されるエージェント関連ディレクトリは `.claude`、`.codex`、`.gemini`、`.opencode`、`.opencode-data` と、その関連 cache である。
+  - `package.json` のグローバルインストール対象は `@openai/codex`、`@anthropic-ai/claude-code`、`@google/gemini-cli`、`opencode-ai` であり、GitHub Copilot CLI は未統合である。
+  - `host/sandbox` には `sandbox codex` 専用フローがあり、tmux セッション生成、`codex resume` 実行、競合引数の拒否、Trust 判定に基づく bootstrap/YOLO 切替までを提供している。
+  - `sandbox tools update` は npm グローバルツール群を一括更新するが、その対象にも GitHub Copilot CLI は含まれていない。
 - 現状の課題（困っていること）:
-  - ...
+  - GitHub Copilot CLI をこのサンドボックス上で既存ツールと同じ運用方法で使えない。
+  - Copilot CLI の設定・認証・LSP 設定などをホスト上で永続化するための `.agent-home` 連携が未実装である。
+  - ツール更新・検証・ヘルプ・テストに Copilot CLI が反映されておらず、統合レベルが揃っていない。
 - 再現手順（最小で）:
-  1) ...
-  2) ...
+  1. `sandbox tools update` を実行して共有 npm グローバルツールを更新する。
+  2. コンテナ内で `copilot --version` または `which copilot` を確認する。
+  3. `sandbox --help` および `sandbox tools --help` を確認する。
+  4. `.agent-home` 配下を確認する。
 - 観測点（どこを見て確認するか）:
-  - UI: ...
-  - HTTP: ...
-  - DB: ...
-  - Log: ...
+  - UI: なし
+  - HTTP: なし
+  - DB: なし
+  - Log:
+    - `tests/sandbox_cli.test.sh` の compose/tmux stub ログ
+    - `sandbox --help` / `sandbox tools --help` / `sandbox copilot --help`
+    - コンテナ内の `copilot --version`
+    - `.agent-home` 配下の作成ディレクトリ
 - 実際の観測結果（貼れる範囲で）:
-  - Input/Operation: ...
-  - Output/State: ...
+  - Input/Operation:
+    - `rg -n "codex|claude|gemini|opencode|agent-home" -S .`
+    - `cat package.json`
+    - `sed -n '1,220p' docker-compose.yml`
+    - `sed -n '1,220p' Dockerfile`
+    - `sed -n '1,1460p' host/sandbox`
+  - Output/State:
+    - `docker-compose.yml` は `.agent-home/.claude`、`.agent-home/.codex`、`.agent-home/.gemini`、`.agent-home/.opencode` などを mount しているが、Copilot 用 mount は無い。
+    - `Dockerfile` は `/home/node/.claude`、`/home/node/.codex`、`/home/node/.gemini`、`/home/node/.config/opencode` 等を事前作成しているが、Copilot 用ディレクトリは無い。
+    - `package.json` の `install-global` / `verify` に Copilot CLI は無い。
+    - `host/sandbox` の help / `ensure_agent_home_dirs` / `tools update` / `codex` サブコマンド群に Copilot CLI は無い。
 - 情報源（ヒアリング/調査の根拠）:
-  - Issue/チケット: ...
-  - ドキュメント: ...
-  - コード: `<path/to/file>`（関数/クラス: ... / 仕様を決めている箇所（行番号）: ... / 読むべき理由） ...
-  - 画面/ログ/DB: ...
+  - ヒアリング:
+    - ユーザー回答（2026-03-19）:
+      - `sandbox copilot` のような専用サブコマンドを追加したい
+      - tmux 経由で起動したい
+      - `COPILOT_HOME` 等で別ディレクトリ指定はせず、GitHub Copilot CLI の標準ディレクトリを使いたい
+      - ただし標準ディレクトリに作られるファイル一式は `.agent-home` から mount して永続化したい
+  - ドキュメント:
+    - GitHub Docs, "Installing GitHub Copilot CLI"（2026-03-19 確認）:
+      - npm インストールは `npm install -g @github/copilot`
+      - npm インストール時の前提は Node.js 22+
+      - URL: `https://docs.github.com/copilot/how-tos/set-up/install-copilot-cli`
+    - GitHub Copilot CLI README（2026-03-19 確認）:
+      - 起動コマンドは `copilot`
+      - ユーザーレベルの LSP 設定は `~/.copilot/lsp-config.json`
+      - URL: `https://github.com/github/copilot-cli`
+  - コード:
+    - `docker-compose.yml`（bind mount の現行仕様）
+    - `Dockerfile`（CLI 設定ディレクトリの初期作成）
+    - `package.json`（グローバルツールのインストール・検証）
+    - `host/sandbox`（CLI サブコマンド、`.agent-home` 初期化、tools update、codex 統合）
+    - `tests/sandbox_cli.test.sh`（CLI 仕様テスト）
 
 ## 対象ユーザー / 利用シナリオ (任意)
 - 主な利用者（ロール）:
-  - ...
+  - この sandbox ツールを使って各種コーディングエージェントを安全に起動する開発者
 - 代表的なシナリオ:
-  - ...
+  - `sandbox tools update` で Copilot CLI を含む共有ツールをインストールする
+  - `sandbox copilot` で tmux セッションを生成または再利用し、コンテナ内で Copilot CLI を起動する
+  - Copilot CLI のログイン情報や `~/.copilot/*` を `.agent-home/.copilot` 経由で永続化する
 
 ## スコープ（暴走防止のガードレール） (必須)
 - MUST（必ずやる）:
-  - ...
+  - GitHub Copilot CLI を Docker イメージと `sandbox tools update` の共有ツール群へ追加する
+  - Copilot CLI の標準ユーザーディレクトリ `~/.copilot` を、ホスト側 `.agent-home/.copilot` から bind mount する
+  - `host/sandbox` に `sandbox copilot [options] -- [copilot args...]` サブコマンドを追加し、tmux セッション経由で `copilot` を起動できるようにする
+  - `help`、`tools update`、`.agent-home` 初期化、Docker mount、テストを Copilot 対応に更新する
+  - 既存 CLI 群の挙動を壊さない
 - MUST NOT（絶対にやらない／追加しない）:
-  - ...
+  - `COPILOT_HOME` などで標準ディレクトリを別パスへ変更する設計にしない
+  - Copilot CLI について `~/.copilot` 以外の XDG/config/cache mount を推測で追加しない
+  - Copilot CLI の認証フローを独自実装しない
+  - 既存の Codex 専用 Trust/YOLO/bootstrap 判定を Copilot CLI に流用しない
+  - GitHub Copilot CLI 以外の新規ツールを同時に追加しない
 - OUT OF SCOPE（今回やらない）:
-  - ...
+  - Copilot CLI の詳細な slash command 運用ガイド整備
+  - Copilot CLI の enterprise policy や課金設定の管理
+  - LSP サーバー自体の自動インストール
+  - 既存 `sandbox codex` の仕様変更
 
 ## 非交渉制約（守るべき制約） (必須)
-- 例: 既存API互換を維持する
-- 例: 依存追加はしない（必要なら要件に明記）
-- 例: セキュリティ/プライバシー要件（ログ、マスキング、権限制御など）
-- 例: 性能（p95など）やSLO
-- ...
+- 既存の `.agent-home` ベースの永続化設計と整合すること
+- Docker コンテナ内では GitHub Copilot CLI の標準ユーザーディレクトリを使うこと
+- `sandbox tools update` の更新対象と `npm run verify` の検証対象を一致させること
+- `sandbox copilot` は `sandbox codex` と同様に tmux セッションを自動生成・再利用すること
+- 既存テストの deterministic な stub ベース戦略を維持し、実 Docker/Git 呼び出しに依存しないこと
+- 既存 CLI の挙動を変更する場合は、互換性維持または明示的な help 更新を行うこと
 
 ## 前提（Assumptions） (必須)
-- 例: 対象ユーザーは〜である
-- 例: 既存データは〜の状態である
-- ...
+- 既存 Dockerfile は Node.js 24 を導入しており、GitHub Copilot CLI の npm 前提 Node.js 22+ を満たす
+- GitHub Copilot CLI のユーザー設定ファイル群は `~/.copilot` 配下に集約される
+- `copilot` コマンドは npm グローバルインストール後に PATH 上で利用可能になる
+- Copilot CLI の利用者は別途有効な GitHub Copilot 利用権限を持つ
 
 ## 判断材料/トレードオフ（Decision / Trade-offs） (任意)
-- 論点: ...
-  - 選択肢A: ...（Pros/Cons）
-  - 選択肢B: ...（Pros/Cons）
-  - 決定: ...
-  - 理由: ...
+- 論点: Copilot CLI の永続化対象をどこまで mount するか
+  - 選択肢A: `~/.copilot` ディレクトリ全体を `.agent-home/.copilot` から mount する
+  - 選択肢B: `config.json` や `lsp-config.json` のみを個別 mount する
+  - 決定: 選択肢A
+  - 理由: ユーザー要望が「インストール時に生成されるディレクトリやファイル一式をローカルへ mount」であり、標準ディレクトリ全体を扱う方が既存ツール群の設計と一致する
+- 論点: Copilot CLI 起動フロー
+  - 選択肢A: `sandbox shell` から手動実行のみサポート
+  - 選択肢B: `sandbox copilot` を追加し tmux 経由で起動
+  - 決定: 選択肢B
+  - 理由: ユーザーが Codex と同水準の統合を要求しているため
 
 ## リスク/懸念（Risks） (任意)
-- R-001: <リスク>（影響: ... / 対応: ...）
-- R-002: ...
+- R-001: GitHub Copilot CLI は発展途上のため、将来設定ディレクトリや起動引数が変わる可能性がある（影響: 維持コスト増 / 対応: 標準ディレクトリと基本起動のみを固定し、過剰な独自制御を避ける）
+- R-002: Copilot CLI は Codex のような Trust/YOLO 概念を公開していないため、起動ラッパーの仕様を必要以上に複雑化できない（影響: 起動制御差異 / 対応: tmux と compose 起動に責務を限定する）
 
 ## 受け入れ条件（観測可能な振る舞い） (必須)
 - AC-001:
-  - Actor/Role: ...
-  - Given: ...
-  - When: ...
-  - Then: ...
-  - 観測点（UI/HTTP/DB/Log など）: ...
-  - 権限/認可条件（ある場合）: ...
+  - Actor/Role: sandbox 利用者
+  - Given: 共有 npm グローバルツールを更新可能な sandbox 環境がある
+  - When: `sandbox tools update` を実行する
+  - Then: GitHub Copilot CLI が既存 CLI 群と同じ更新フローに含まれ、コンテナ内で `copilot --version` が実行可能になる
+  - 観測点（UI/HTTP/DB/Log など）: `package.json`、`sandbox tools update` の compose 実行ログ、`npm run verify`
+  - 権限/認可条件（ある場合）: npm パッケージ取得が可能であること
 - AC-002:
-  - Actor/Role: ...
-  - Given: ...
-  - When: ...
-  - Then: ...
-  - 観測点（UI/HTTP/DB/Log など）: ...
-  - 権限/認可条件（ある場合）: ...
+  - Actor/Role: sandbox 利用者
+  - Given: sandbox ルート配下に `.agent-home` がある
+  - When: `sandbox up` / `sandbox shell` / `sandbox copilot` の前処理を行う
+  - Then: `.agent-home/.copilot` が作成され、コンテナ内の標準ディレクトリ `~/.copilot` に bind mount される
+  - 観測点（UI/HTTP/DB/Log など）: `.agent-home` ディレクトリ、`docker-compose.yml`、`Dockerfile`
+  - 権限/認可条件（ある場合）: なし
+- AC-003:
+  - Actor/Role: sandbox 利用者
+  - Given: Docker と tmux が利用可能で、対象の workdir / mount-root が解決可能である
+  - When: `sandbox copilot [options] -- [copilot args...]` を実行する
+  - Then: tmux セッションを生成または再利用し、その内側で sandbox を起動した上でコンテナ内 workdir で `copilot [copilot args...]` を実行し、終了後は zsh に戻る
+  - 観測点（UI/HTTP/DB/Log など）: tmux stub ログ、compose exec ログ、help 出力
+  - 権限/認可条件（ある場合）: Docker と tmux が PATH 上で利用可能であること
+- AC-004:
+  - Actor/Role: sandbox 利用者
+  - Given: `sandbox --help`、`sandbox tools --help`、`sandbox copilot --help` を参照する
+  - When: Help を表示する
+  - Then: Copilot CLI が既存ツール群の一員として help 文面に反映され、更新対象やサブコマンド一覧が理解できる
+  - 観測点（UI/HTTP/DB/Log など）: stdout の help テキスト
+  - 権限/認可条件（ある場合）: なし
 
 ### 入力→出力例 (任意)
 - EX-001:
-  - Input: ...
-  - Output: ...
+  - Input: `sandbox tools update --mount-root /path/to/repo --workdir /path/to/repo`
+  - Output: compose run ログに Copilot CLI を含む `npm run install-global` が実行される
 - EX-002:
-  - Input: ...
-  - Output: ...
+  - Input: `sandbox copilot --mount-root /path/to/repo --workdir /path/to/repo/subdir -- --help`
+  - Output: tmux セッション生成後、compose exec が `/srv/mount/.../subdir` を workdir にして `copilot --help` を起動する
 
 ## 例外・エッジケース（仕様として固定） (必須)
 - EC-001:
-  - 条件: ...
-  - 期待: ...（例: HTTP 4xx/5xx, エラーコード, 表示文言, ログ, DB状態）
-  - 観測点（UI/HTTP/DB/Log など）: ...
+  - 条件: `sandbox copilot` 実行時に tmux が存在しない
+  - 期待: `sandbox codex` と同様に即座にエラー終了し、tmux 未導入を stderr に表示する
+  - 観測点（UI/HTTP/DB/Log など）: stderr、終了コード
 - EC-002:
-  - 条件: ...
-  - 期待: ...
-  - 観測点: ...
+  - 条件: `sandbox copilot --help` またはトップレベル help を表示する
+  - 期待: `.env` や `.agent-home` を作成せず、副作用なく help だけを返す
+  - 観測点（UI/HTTP/DB/Log など）: stdout、ファイルシステム、副作用の有無
+- EC-005:
+  - 条件: `sandbox copilot --mount-root <root> --workdir <dir> -- --help` を実行する
+  - 期待: sandbox 側の help ではなく、`--` より後ろの引数として `copilot --help` がコンテナ内へそのまま渡される
+  - 観測点（UI/HTTP/DB/Log など）: compose exec ログ、stdout
+- EC-003:
+  - 条件: `sandbox tools update` 実行時に update lock が存在する
+  - 期待: 既存動作と同様にロック競合エラーで停止し、Copilot 追加によってロック動作は変化しない
+  - 観測点（UI/HTTP/DB/Log など）: stderr、compose ログに `CMD=` が出ないこと
+- EC-004:
+  - 条件: Copilot CLI の標準ディレクトリにファイルが無い初回状態で sandbox を起動する
+  - 期待: `.agent-home/.copilot` を先に作成して mount できる
+  - 観測点（UI/HTTP/DB/Log など）: `.agent-home/.copilot` の存在
 
 ## 用語（ドメイン語彙） (必須)
-- TERM-001: <用語> = <定義>
-- TERM-002: ...
+- TERM-001: Agent Home = ホスト側 `.agent-home` 配下に置く、各 CLI の設定・認証・キャッシュ等の永続化ディレクトリ群
+- TERM-002: 標準ディレクトリ = 各 CLI が環境変数による上書きを行わない場合に既定で使用するホーム配下のディレクトリ
+- TERM-003: Copilot CLI = npm パッケージ `@github/copilot` により提供される `copilot` コマンド
+- TERM-004: tmux ラッパー = `sandbox codex` と同様に、ホスト側で tmux セッションを張ってコンテナ実行を包む起動方式
 
 ## 未確定事項（TBD / 要確認） (必須)
-- Q-001:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: AC-___ / EC-___ / スコープ / 制約 / ...
-- Q-002:
-  - 質問: TBD ...
-  - 選択肢:
-    - A: ...
-    - B: ...
-  - 推奨案（暫定）: ...
-  - 影響範囲: ...
+- 該当なし
+
+## 合意済み決定事項 (任意)
+- D-001: `sandbox copilot` の CLI 契約は `sandbox copilot [options] -- [copilot args...]` とし、`--` より後ろは検証・禁止せず `copilot` に pass-through する
+- D-002: `npm run verify` の Copilot 検証は `copilot --version` に固定する
 
 ## 完了条件（Definition of Done） (必須)
 - すべてのAC/ECが満たされる
-- 未確定事項が解消される（残す場合は「残す理由」と「合意」を明記）
-- MUST NOT / OUT OF SCOPE を破っていない（追加機能を入れていない）
+- 未確定事項が解消される、または残す場合は理由と合意が明記される
+- MUST NOT / OUT OF SCOPE を破っていない
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `sandbox up` — build and start the container via Docker Compose.
 - `sandbox shell` — open `/bin/zsh` inside the container (starts it if needed).
 - `sandbox status|stop|down` — inspect/stop/remove the container.
-- (Inside container) `npm run verify` — sanity-check installed CLIs (codex/claude/gemini/opencode).
+- (Inside container) `npm run verify` — sanity-check installed CLIs (codex/claude/copilot/gemini/opencode).
 
 ## Coding Style & Naming Conventions
 - Bash-first repo: scripts use `#!/bin/bash` and `set -euo pipefail`; prefer explicit quoting and `local` variables.

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,8 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 # Create sandbox and workspace directories and set permissions
 # /opt/sandbox: Internal sandbox tools (isolated from host)
 # /srv/${PRODUCT_NAME}: Legacy workspace path (container-side). Dynamic mount uses /srv/mount at runtime.
-RUN mkdir -p /opt/sandbox /srv/${PRODUCT_NAME} /home/node/.claude /home/node/.codex /home/node/.gemini /home/node/.config/opencode /home/node/.local/share/opencode /home/node/.cache/opencode /home/node/.config/nvim && \
-  chown -R node:node /opt/sandbox /srv/${PRODUCT_NAME} /home/node/.claude /home/node/.codex /home/node/.gemini /home/node/.config /home/node/.local /home/node/.cache && \
+RUN mkdir -p /opt/sandbox /srv/${PRODUCT_NAME} /home/node/.claude /home/node/.copilot /home/node/.codex /home/node/.gemini /home/node/.config/opencode /home/node/.local/share/opencode /home/node/.cache/opencode /home/node/.config/nvim && \
+  chown -R node:node /opt/sandbox /srv/${PRODUCT_NAME} /home/node/.claude /home/node/.copilot /home/node/.codex /home/node/.gemini /home/node/.config /home/node/.local /home/node/.cache && \
   ln -s /home/node/.codex /home/node/.config/codex || true && \
   ln -s /home/node/.gemini /home/node/.config/gemini || true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - sandbox-npm-cache:/home/node/.npm/_cache
       - ./.agent-home/commandhistory:/commandhistory
       - ./.agent-home/.claude:/home/node/.claude
+      - ./.agent-home/.copilot:/home/node/.copilot
       - ./.agent-home/.codex:/home/node/.codex
       - ./.agent-home/.gemini:/home/node/.gemini
       - ./.agent-home/.opencode:/home/node/.config/opencode

--- a/host/sandbox
+++ b/host/sandbox
@@ -455,6 +455,27 @@ copilot_requests_programmatic_mode() {
     return 1
 }
 
+copilot_requests_headless_mode() {
+    if copilot_requests_programmatic_mode "$@"; then
+        return 0
+    fi
+
+    if [[ $# -eq 0 && ! -t 0 ]]; then
+        return 0
+    fi
+
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            help|version|-v|--version|--help)
+                return 0
+                ;;
+        esac
+    done
+
+    return 1
+}
+
 copilot_has_approval_override() {
     local allow_all="${COPILOT_ALLOW_ALL:-}"
     if [[ -n "$allow_all" ]]; then
@@ -477,6 +498,9 @@ copilot_has_approval_override() {
             --allow-all-tools|--allow-all-tools=*)
                 return 0
                 ;;
+            --allow-all|--allow-all=*|--yolo|--yolo=*)
+                return 0
+                ;;
             --allow-tool)
                 expect_allow_tool_value=true
                 ;;
@@ -495,9 +519,13 @@ validate_copilot_invocation() {
 
     if copilot_requests_programmatic_mode "$@"; then
         if ! copilot_has_approval_override "$@"; then
-            echo "Programmatic copilot usage with -p/--prompt requires --allow-all-tools, --allow-tool <tool>, or COPILOT_ALLOW_ALL." >&2
+            echo "Programmatic copilot usage with -p/--prompt requires --allow-all-tools, --allow-tool <tool>, --allow-all, --yolo, or COPILOT_ALLOW_ALL." >&2
             return 1
         fi
+        return 0
+    fi
+
+    if copilot_requests_headless_mode "$@"; then
         return 0
     fi
 
@@ -513,7 +541,7 @@ copilot_should_use_tmux() {
     if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
         return 0
     fi
-    if copilot_requests_programmatic_mode "$@"; then
+    if copilot_requests_headless_mode "$@"; then
         return 1
     fi
     if [[ ! -t 0 || ! -t 1 ]]; then
@@ -1300,7 +1328,8 @@ Options:
   -h, --help
 Notes:
   Arguments after "--" are passed to copilot (e.g., sandbox copilot -- --help).
-  Noninteractive -p/--prompt usage requires --allow-all-tools, --allow-tool, or COPILOT_ALLOW_ALL.
+  Headless help/version invocations run without tmux.
+  Noninteractive -p/--prompt usage requires --allow-all-tools, --allow-tool, --allow-all, --yolo, or COPILOT_ALLOW_ALL.
   必要な場合は sandbox shell で copilot を直接実行してください。
 USAGE
 }

--- a/host/sandbox
+++ b/host/sandbox
@@ -277,12 +277,21 @@ run_compose_exec_copilot() {
     local container_name="$2"
     local compose_project_name="$3"
     local abs_mount_root="$4"
-    shift 4
+    local interactive_mode="$5"
+    shift 5
     prepare_compose_env "$container_name" "$compose_project_name" "$abs_mount_root"
-    if [[ $# -gt 0 ]]; then
-        run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"; exec /bin/zsh' -- "$@"
+    if [[ "$interactive_mode" == "true" ]]; then
+        if [[ $# -gt 0 ]]; then
+            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"; status=$?; if [[ $status -eq 0 ]]; then exec /bin/zsh; fi; exit $status' -- "$@"
+        else
+            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot; status=$?; if [[ $status -eq 0 ]]; then exec /bin/zsh; fi; exit $status'
+        fi
     else
-        run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot; exec /bin/zsh'
+        if [[ $# -gt 0 ]]; then
+            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"' -- "$@"
+        else
+            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot'
+        fi
     fi
 }
 
@@ -432,6 +441,31 @@ split_copilot_args() {
             COPILOT_SANDBOX_ARGS+=("$arg")
         fi
     done
+}
+
+copilot_requests_programmatic_mode() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -p|--prompt|--prompt=*|-p*|-s|--silent)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+copilot_should_use_tmux() {
+    if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
+        return 0
+    fi
+    if [[ ! -t 0 ]]; then
+        return 1
+    fi
+    if copilot_requests_programmatic_mode "$@"; then
+        return 1
+    fi
+    return 0
 }
 
 codex_args_have_conflicts() {
@@ -1374,7 +1408,18 @@ main() {
 
     if [[ "$subcommand" == "copilot" ]]; then
         split_copilot_args "$@"
-        if [[ -z "${SANDBOX_COPILOT_NO_TMUX:-}" ]]; then
+        local copilot_use_tmux=false
+        if (( ${#COPILOT_ARGS[@]} > 0 )); then
+            if copilot_should_use_tmux "${COPILOT_ARGS[@]}"; then
+                copilot_use_tmux=true
+            fi
+        else
+            if copilot_should_use_tmux; then
+                copilot_use_tmux=true
+            fi
+        fi
+
+        if [[ -z "${SANDBOX_COPILOT_NO_TMUX:-}" ]] && [[ "$copilot_use_tmux" == true ]]; then
             if ! ensure_tmux_available; then
                 exit 1
             fi
@@ -1425,10 +1470,14 @@ main() {
             exit 1
         fi
         run_compose_up "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT"
+        local copilot_interactive_mode=false
+        if [[ "$copilot_use_tmux" == true ]]; then
+            copilot_interactive_mode=true
+        fi
         if (( ${#COPILOT_ARGS[@]} > 0 )); then
-            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT" "${COPILOT_ARGS[@]}"
+            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT" "$copilot_interactive_mode" "${COPILOT_ARGS[@]}"
         else
-            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT"
+            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT" "$copilot_interactive_mode"
         fi
         exit $?
     fi

--- a/host/sandbox
+++ b/host/sandbox
@@ -467,7 +467,7 @@ copilot_requests_headless_mode() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            help|version|init|update|plugin|login|logout|-v|--version|--help)
+            help|version|init|update|plugin|login|logout|-v|--version|--help|--acp)
                 return 0
                 ;;
         esac

--- a/host/sandbox
+++ b/host/sandbox
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 CALLER_PWD="${CALLER_PWD:-$(pwd)}"
+COPILOT_SANDBOX_ARGS=()
+COPILOT_ARGS=()
+COPILOT_HAS_DOUBLE_DASH=false
 CODEX_SANDBOX_ARGS=()
 CODEX_ARGS=()
 CODEX_HAS_DOUBLE_DASH=false
@@ -96,6 +99,7 @@ ensure_agent_home_dirs() {
     local base="$SANDBOX_ROOT/.agent-home"
     mkdir -p \
         "$base/.claude" \
+        "$base/.copilot" \
         "$base/.codex" \
         "$base/.gemini" \
         "$base/.opencode" \
@@ -268,6 +272,20 @@ run_compose_exec_codex() {
     fi
 }
 
+run_compose_exec_copilot() {
+    local container_workdir="$1"
+    local container_name="$2"
+    local compose_project_name="$3"
+    local abs_mount_root="$4"
+    shift 4
+    prepare_compose_env "$container_name" "$compose_project_name" "$abs_mount_root"
+    if [[ $# -gt 0 ]]; then
+        run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"; exec /bin/zsh' -- "$@"
+    else
+        run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot; exec /bin/zsh'
+    fi
+}
+
 run_compose_build() {
     local container_name="$1"
     local compose_project_name="$2"
@@ -392,6 +410,26 @@ split_codex_args() {
             CODEX_ARGS+=("$arg")
         else
             CODEX_SANDBOX_ARGS+=("$arg")
+        fi
+    done
+}
+
+split_copilot_args() {
+    COPILOT_SANDBOX_ARGS=()
+    COPILOT_ARGS=()
+    COPILOT_HAS_DOUBLE_DASH=false
+
+    local seen_double_dash=false
+    for arg in "$@"; do
+        if [[ "$seen_double_dash" == false && "$arg" == "--" ]]; then
+            seen_double_dash=true
+            COPILOT_HAS_DOUBLE_DASH=true
+            continue
+        fi
+        if [[ "$seen_double_dash" == true ]]; then
+            COPILOT_ARGS+=("$arg")
+        else
+            COPILOT_SANDBOX_ARGS+=("$arg")
         fi
     done
 }
@@ -949,6 +987,14 @@ compute_codex_session_name() {
     echo "${base}-codex-sandbox"
 }
 
+compute_copilot_session_name() {
+    local base
+    base="$(basename "$CALLER_PWD")"
+    base="${base//:/_}"
+    base="${base//./_}"
+    echo "${base}-copilot-sandbox"
+}
+
 ensure_docker_available() {
     if ! command -v docker >/dev/null 2>&1; then
         echo "docker command not found" >&2
@@ -1026,6 +1072,7 @@ Commands:
   status   Show container status
   name     Print computed container name
   codex    Start tmux + sandbox + codex resume
+  copilot  Start tmux + sandbox + copilot
   help     Show this help
 
 Options:
@@ -1040,7 +1087,7 @@ print_help_tools() {
 Usage: sandbox tools <command> [options]
 
 Commands:
-  update   Update shared npm global tools (codex/claude/gemini/opencode, etc.)
+  update   Update shared npm global tools (codex/claude/copilot/gemini/opencode, etc.)
 
 Options:
   --mount-root <path>
@@ -1154,8 +1201,26 @@ Notes:
 USAGE
 }
 
+print_help_copilot() {
+    cat <<'USAGE'
+Usage: sandbox copilot [options] -- [copilot args...]
+
+Create/attach a tmux session, start the sandbox, and run "copilot".
+Options:
+  --mount-root <path>
+  --workdir <path>
+  -h, --help
+Notes:
+  Arguments after "--" are passed to copilot (e.g., sandbox copilot -- --help).
+  必要な場合は sandbox shell で copilot を直接実行してください。
+USAGE
+}
+
 main() {
     CALLER_PWD="${CALLER_PWD:-$(pwd)}"
+    COPILOT_SANDBOX_ARGS=()
+    COPILOT_ARGS=()
+    COPILOT_HAS_DOUBLE_DASH=false
     CODEX_SANDBOX_ARGS=()
     CODEX_ARGS=()
     CODEX_HAS_DOUBLE_DASH=false
@@ -1179,7 +1244,7 @@ main() {
                 ;;
         esac
         case "$arg" in
-            shell|up|build|tools|stop|down|status|name|help|codex)
+            shell|up|build|tools|stop|down|status|name|help|codex|copilot)
                 subcommand="$arg"
             ;;
             *)
@@ -1190,9 +1255,15 @@ main() {
     done
 
     local has_help_flag=false
-    if [[ "$subcommand" == "codex" ]]; then
-        split_codex_args "$@"
-        for arg in "${CODEX_SANDBOX_ARGS[@]}"; do
+    if [[ "$subcommand" == "codex" || "$subcommand" == "copilot" ]]; then
+        if [[ "$subcommand" == "codex" ]]; then
+            split_codex_args "$@"
+            local help_args=("${CODEX_SANDBOX_ARGS[@]}")
+        else
+            split_copilot_args "$@"
+            local help_args=("${COPILOT_SANDBOX_ARGS[@]}")
+        fi
+        for arg in "${help_args[@]}"; do
             if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
                 has_help_flag=true
                 break
@@ -1218,6 +1289,7 @@ main() {
             status) print_help_status ;;
             name)   print_help_name ;;
             codex)  print_help_codex ;;
+            copilot) print_help_copilot ;;
             *)      print_help ;;
         esac
         exit 0
@@ -1297,6 +1369,67 @@ main() {
             codex_resume_args+=("${CODEX_ARGS[@]}")
         fi
         run_compose_exec_codex "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT" "${codex_resume_args[@]}"
+        exit $?
+    fi
+
+    if [[ "$subcommand" == "copilot" ]]; then
+        split_copilot_args "$@"
+        if [[ -z "${SANDBOX_COPILOT_NO_TMUX:-}" ]]; then
+            if ! ensure_tmux_available; then
+                exit 1
+            fi
+            local session_name
+            session_name="$(compute_copilot_session_name)"
+            local cmd=()
+            cmd+=(env SANDBOX_COPILOT_NO_TMUX=1 "$SCRIPT_PATH")
+            cmd+=("${COPILOT_SANDBOX_ARGS[@]}")
+            if [[ "$COPILOT_HAS_DOUBLE_DASH" == true ]]; then
+                cmd+=(--)
+                if (( ${#COPILOT_ARGS[@]} > 0 )); then
+                    cmd+=("${COPILOT_ARGS[@]}")
+                fi
+            fi
+            if tmux has-session -t "=$session_name" 2>/dev/null; then
+                if [[ -n "${TMUX:-}" ]]; then
+                    tmux switch-client -t "=$session_name"
+                else
+                    tmux attach-session -t "=$session_name"
+                fi
+            else
+                tmux new-session -d -s "$session_name" -c "$CALLER_PWD" "${cmd[@]}"
+                if [[ -n "${TMUX:-}" ]]; then
+                    tmux switch-client -t "=$session_name"
+                else
+                    tmux attach-session -t "=$session_name"
+                fi
+            fi
+            exit 0
+        fi
+
+        parse_common_args "${COPILOT_SANDBOX_ARGS[@]}"
+        if ! determine_paths; then
+            exit 1
+        fi
+        if ! ensure_docker_available; then
+            exit 1
+        fi
+        local container_name
+        container_name="$(compute_container_name "$ABS_MOUNT_ROOT" "$ABS_WORKDIR")"
+        local compose_project_name
+        compose_project_name="$(compute_compose_project_name "$ABS_MOUNT_ROOT" "$ABS_WORKDIR")"
+        local container_workdir
+        container_workdir="$(compute_container_workdir "$ABS_MOUNT_ROOT" "$ABS_WORKDIR")"
+        ensure_env_file
+        ensure_agent_home_dirs
+        if ! select_compose_cmd; then
+            exit 1
+        fi
+        run_compose_up "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT"
+        if (( ${#COPILOT_ARGS[@]} > 0 )); then
+            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT" "${COPILOT_ARGS[@]}"
+        else
+            run_compose_exec_copilot "$container_workdir" "$container_name" "$compose_project_name" "$ABS_MOUNT_ROOT"
+        fi
         exit $?
     fi
 

--- a/host/sandbox
+++ b/host/sandbox
@@ -467,10 +467,13 @@ copilot_requests_headless_mode() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            help|version|-v|--version|--help)
+            help|version|init|update|plugin|login|logout|-v|--version|--help)
                 return 0
                 ;;
         esac
+        if [[ "$arg" != -* ]]; then
+            break
+        fi
     done
 
     return 1
@@ -1105,10 +1108,12 @@ compute_codex_session_name() {
 
 compute_copilot_session_name() {
     local base
+    local hash12
     base="$(basename "$CALLER_PWD")"
     base="${base//:/_}"
     base="${base//./_}"
-    echo "${base}-copilot-sandbox"
+    hash12="$(compute_hash12 "$CALLER_PWD")"
+    echo "${base}-${hash12}-copilot-sandbox"
 }
 
 ensure_docker_available() {

--- a/host/sandbox
+++ b/host/sandbox
@@ -288,9 +288,9 @@ run_compose_exec_copilot() {
         fi
     else
         if [[ $# -gt 0 ]]; then
-            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"' -- "$@"
+            run_compose exec -T -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot "$@"' -- "$@"
         else
-            run_compose exec -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot'
+            run_compose exec -T -w "$container_workdir" agent-sandbox /bin/zsh -lc 'copilot'
         fi
     fi
 }
@@ -459,7 +459,7 @@ copilot_should_use_tmux() {
     if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
         return 0
     fi
-    if [[ ! -t 0 ]]; then
+    if [[ ! -t 0 || ! -t 1 ]]; then
         return 1
     fi
     if copilot_requests_programmatic_mode "$@"; then

--- a/host/sandbox
+++ b/host/sandbox
@@ -447,7 +447,7 @@ copilot_requests_programmatic_mode() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            -p|--prompt|--prompt=*|-p*|-s|--silent)
+            -p|--prompt|--prompt=*|-p*)
                 return 0
                 ;;
         esac
@@ -455,14 +455,68 @@ copilot_requests_programmatic_mode() {
     return 1
 }
 
+copilot_has_approval_override() {
+    local allow_all="${COPILOT_ALLOW_ALL:-}"
+    if [[ -n "$allow_all" ]]; then
+        case "${allow_all,,}" in
+            0|false|no|off)
+                ;;
+            *)
+                return 0
+                ;;
+        esac
+    fi
+
+    local expect_allow_tool_value=false
+    local arg
+    for arg in "$@"; do
+        if [[ "$expect_allow_tool_value" == true ]]; then
+            return 0
+        fi
+        case "$arg" in
+            --allow-all-tools|--allow-all-tools=*)
+                return 0
+                ;;
+            --allow-tool)
+                expect_allow_tool_value=true
+                ;;
+            --allow-tool=*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+validate_copilot_invocation() {
+    if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
+        return 0
+    fi
+
+    if copilot_requests_programmatic_mode "$@"; then
+        if ! copilot_has_approval_override "$@"; then
+            echo "Programmatic copilot usage with -p/--prompt requires --allow-all-tools, --allow-tool <tool>, or COPILOT_ALLOW_ALL." >&2
+            return 1
+        fi
+        return 0
+    fi
+
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        echo "Interactive copilot usage requires a TTY on stdin and stdout. Use sandbox copilot -- -- -p ... with approval flags for noninteractive execution." >&2
+        return 1
+    fi
+
+    return 0
+}
+
 copilot_should_use_tmux() {
     if [[ -n "${SANDBOX_COPILOT_FORCE_TMUX:-}" ]]; then
         return 0
     fi
-    if [[ ! -t 0 || ! -t 1 ]]; then
+    if copilot_requests_programmatic_mode "$@"; then
         return 1
     fi
-    if copilot_requests_programmatic_mode "$@"; then
+    if [[ ! -t 0 || ! -t 1 ]]; then
         return 1
     fi
     return 0
@@ -1246,6 +1300,7 @@ Options:
   -h, --help
 Notes:
   Arguments after "--" are passed to copilot (e.g., sandbox copilot -- --help).
+  Noninteractive -p/--prompt usage requires --allow-all-tools, --allow-tool, or COPILOT_ALLOW_ALL.
   必要な場合は sandbox shell で copilot を直接実行してください。
 USAGE
 }
@@ -1408,6 +1463,15 @@ main() {
 
     if [[ "$subcommand" == "copilot" ]]; then
         split_copilot_args "$@"
+        if (( ${#COPILOT_ARGS[@]} > 0 )); then
+            if ! validate_copilot_invocation "${COPILOT_ARGS[@]}"; then
+                exit 1
+            fi
+        else
+            if ! validate_copilot_invocation; then
+                exit 1
+            fi
+        fi
         local copilot_use_tmux=false
         if (( ${#COPILOT_ARGS[@]} > 0 )); then
             if copilot_should_use_tmux "${COPILOT_ARGS[@]}"; then

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "dependencies": {
     "@openai/codex": "latest",
     "@anthropic-ai/claude-code": "latest",
+    "@github/copilot": "latest",
     "@google/gemini-cli": "latest",
     "@sasazame/ccresume": "latest",
     "opencode-ai": "latest"
   },
   "scripts": {
-    "install-global": "npm install -g @anthropic-ai/claude-code @google/gemini-cli @sasazame/ccresume @openai/codex opencode-ai",
-    "verify": "claude --version && gemini --version && opencode --version && npx -y @openai/codex --version"
+    "install-global": "npm install -g @anthropic-ai/claude-code @github/copilot @google/gemini-cli @sasazame/ccresume @openai/codex opencode-ai",
+    "verify": "claude --version && copilot --version && gemini --version && opencode --version && npx -y @openai/codex --version"
   },
   "keywords": [
     "docker",

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -77,6 +77,9 @@ if [[ "$1" == "compose" ]]; then
             echo "TZ=${TZ-}"
         fi
     } >> "${STUB_DOCKER_LOG}"
+    if [[ "${1:-}" == "exec" ]]; then
+        exit "${STUB_DOCKER_COMPOSE_EXEC_EXIT:-0}"
+    fi
     exit 0
 fi
 
@@ -1435,7 +1438,7 @@ copilot_outer_uses_tmux_and_session_name() {
     local base_dir="$tmp_dir/My.Project:One"
     mkdir -p "$base_dir"
 
-    CALLER_PWD="$base_dir" run_cmd "$tmp_dir/host/sandbox" copilot
+    run_cmd env CALLER_PWD="$base_dir" SANDBOX_COPILOT_FORCE_TMUX=1 "$tmp_dir/host/sandbox" copilot
     assert_exit_code 0 "$RUN_CODE"
 
     local expected_session="My_Project_One-copilot-sandbox"
@@ -1460,11 +1463,12 @@ copilot_inner_runs_copilot_and_returns_to_zsh() {
     local workdir="$root/subdir"
     setup_env_for_up "$tmp_dir" "$root" "$workdir"
 
-    SANDBOX_COPILOT_NO_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$workdir"
+    SANDBOX_COPILOT_NO_TMUX=1 SANDBOX_COPILOT_FORCE_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$workdir"
     assert_exit_code 0 "$RUN_CODE"
     assert_log_contains "$log_file" "CMD=docker compose up -d --build"
     assert_log_contains "$log_file" "CMD=docker compose exec -w /srv/mount/project/subdir"
     assert_log_contains "$log_file" "copilot"
+    assert_log_contains "$log_file" 'exit\ \$status'
     assert_log_contains "$log_file" "exec\\ /bin/zsh"
 }
 
@@ -1499,12 +1503,82 @@ copilot_errors_when_tmux_missing() {
     ln -sf "$(command -v realpath)" "$no_tmux_path/realpath"
     ln -sf "$(command -v readlink)" "$no_tmux_path/readlink"
 
-    run_cmd env -i HOME="$tmp_dir" PATH="$no_tmux_path" /bin/bash "$tmp_dir/host/sandbox" copilot
+    run_cmd env -i HOME="$tmp_dir" PATH="$no_tmux_path" SANDBOX_COPILOT_FORCE_TMUX=1 /bin/bash "$tmp_dir/host/sandbox" copilot
     if [[ "$RUN_CODE" -eq 0 ]]; then
         echo "Expected tmux error for copilot" >&2
         return 1
     fi
     assert_stderr_contains "tmux command not found" "$RUN_STDERR"
+}
+
+copilot_noninteractive_bypasses_tmux() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local stderr_file
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" -s 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux to be used for noninteractive copilot" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -w /srv/mount/project"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_contains "$log_file" "-p"
+    assert_log_contains "$log_file" "Say\\ hello"
+    assert_log_contains "$log_file" "-s"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
+copilot_noninteractive_preserves_exit_status() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+    export STUB_DOCKER_COMPOSE_EXEC_EXIT=42
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local stderr_file
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" -s 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+    unset STUB_DOCKER_COMPOSE_EXEC_EXIT
+
+    assert_exit_code 42 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux to be used for noninteractive copilot" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
 run_test "help_top_level" help_top_level
@@ -1559,3 +1633,5 @@ run_test "copilot_outer_uses_tmux_and_session_name" copilot_outer_uses_tmux_and_
 run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copilot_and_returns_to_zsh
 run_test "copilot_help_flag_after_double_dash_is_passed_to_copilot" copilot_help_flag_after_double_dash_is_passed_to_copilot
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
+run_test "copilot_noninteractive_bypasses_tmux" copilot_noninteractive_bypasses_tmux
+run_test "copilot_noninteractive_preserves_exit_status" copilot_noninteractive_preserves_exit_status

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -1472,10 +1472,12 @@ copilot_inner_runs_copilot_and_returns_to_zsh() {
     assert_log_contains "$log_file" "exec\\ /bin/zsh"
 }
 
-copilot_help_flag_after_double_dash_is_passed_to_copilot() {
+copilot_help_flag_after_double_dash_uses_direct_exec() {
     local tmp_dir
     tmp_dir="$(make_fake_sandbox_root)"
     setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
     local log_file="$COMPOSE_LOG_FILE"
     export STUB_DOCKER_INFO_EXIT=0
     export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
@@ -1483,14 +1485,47 @@ copilot_help_flag_after_double_dash_is_passed_to_copilot() {
     local root="$tmp_dir/project"
     setup_env_for_up "$tmp_dir" "$root" "$root"
 
-    SANDBOX_COPILOT_NO_TMUX=1 SANDBOX_COPILOT_FORCE_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --help
+    run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --help
     assert_exit_code 0 "$RUN_CODE"
     if [[ "$RUN_STDOUT" == *"Usage: sandbox"* ]]; then
         echo "Sandbox help was printed unexpectedly" >&2
         return 1
     fi
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux for copilot --help" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
     assert_log_contains "$log_file" "--help"
     assert_log_contains "$log_file" "copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
+copilot_version_flag_uses_direct_exec() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --version
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux for copilot --version" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "--version"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
 copilot_errors_when_tmux_missing() {
@@ -1617,6 +1652,90 @@ copilot_programmatic_requires_approval_override() {
     assert_log_not_contains "$log_file" "CMD="
 }
 
+copilot_programmatic_accepts_allow_all_aliases() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local stderr_file
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" --allow-all 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux with --allow-all" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "--allow-all"
+    : > "$log_file"
+    : > "$tmux_log"
+
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" --yolo 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux with --yolo" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "--yolo"
+}
+
+copilot_stdin_option_stream_uses_direct_exec() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local stderr_file
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf '%s\n' '--version' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux for stdin option stream" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "/bin/zsh -lc copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
 copilot_redirected_stdout_errors_for_interactive_mode() {
     local tmp_dir
     tmp_dir="$(make_fake_sandbox_root)"
@@ -1632,8 +1751,11 @@ copilot_redirected_stdout_errors_for_interactive_mode() {
 
     local out_file="$tmp_dir/copilot.out"
     local stderr_file="$tmp_dir/copilot.err"
+    local command_string
+    printf -v command_string '%q copilot --mount-root %q --workdir %q >%q 2>%q' \
+        "$tmp_dir/host/sandbox" "$root" "$root" "$out_file" "$stderr_file"
     set +e
-    "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" >"$out_file" 2>"$stderr_file"
+    script -q /dev/null /bin/bash -lc "$command_string" >/dev/null
     RUN_CODE=$?
     RUN_STDOUT="$(cat "$out_file" 2>/dev/null || true)"
     RUN_STDERR="$(cat "$stderr_file" 2>/dev/null || true)"
@@ -1702,9 +1824,12 @@ run_test "codex_help_flag_after_double_dash_is_passed_to_codex" codex_help_flag_
 run_test "codex_errors_when_tmux_missing" codex_errors_when_tmux_missing
 run_test "copilot_outer_uses_tmux_and_session_name" copilot_outer_uses_tmux_and_session_name
 run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copilot_and_returns_to_zsh
-run_test "copilot_help_flag_after_double_dash_is_passed_to_copilot" copilot_help_flag_after_double_dash_is_passed_to_copilot
+run_test "copilot_help_flag_after_double_dash_uses_direct_exec" copilot_help_flag_after_double_dash_uses_direct_exec
+run_test "copilot_version_flag_uses_direct_exec" copilot_version_flag_uses_direct_exec
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
 run_test "copilot_programmatic_requires_approval_override" copilot_programmatic_requires_approval_override
+run_test "copilot_programmatic_accepts_allow_all_aliases" copilot_programmatic_accepts_allow_all_aliases
 run_test "copilot_noninteractive_bypasses_tmux" copilot_noninteractive_bypasses_tmux
+run_test "copilot_stdin_option_stream_uses_direct_exec" copilot_stdin_option_stream_uses_direct_exec
 run_test "copilot_redirected_stdout_errors_for_interactive_mode" copilot_redirected_stdout_errors_for_interactive_mode
 run_test "copilot_noninteractive_preserves_exit_status" copilot_noninteractive_preserves_exit_status

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -1539,7 +1539,7 @@ copilot_noninteractive_bypasses_tmux() {
         cat "$tmux_log" >&2
         return 1
     fi
-    assert_log_contains "$log_file" "CMD=docker compose exec -w /srv/mount/project"
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
     assert_log_contains "$log_file" "copilot"
     assert_log_contains "$log_file" "-p"
     assert_log_contains "$log_file" "Say\\ hello"
@@ -1577,6 +1577,33 @@ copilot_noninteractive_preserves_exit_status() {
         cat "$tmux_log" >&2
         return 1
     fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
+copilot_redirected_stdout_bypasses_tmux() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local out_file="$tmp_dir/copilot.out"
+    "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" >"$out_file"
+
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux to be used when stdout is redirected" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
     assert_log_contains "$log_file" "copilot"
     assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
@@ -1634,4 +1661,5 @@ run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copi
 run_test "copilot_help_flag_after_double_dash_is_passed_to_copilot" copilot_help_flag_after_double_dash_is_passed_to_copilot
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
 run_test "copilot_noninteractive_bypasses_tmux" copilot_noninteractive_bypasses_tmux
+run_test "copilot_redirected_stdout_bypasses_tmux" copilot_redirected_stdout_bypasses_tmux
 run_test "copilot_noninteractive_preserves_exit_status" copilot_noninteractive_preserves_exit_status

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -213,9 +213,42 @@ help_top_level() {
     run_cmd "$tmp_dir/host/sandbox" -h
     assert_exit_code 0 "$RUN_CODE"
     assert_stdout_contains "Usage:" "$RUN_STDOUT"
+    assert_stdout_contains "copilot" "$RUN_STDOUT"
 
     assert_no_files_created "$tmp_dir"
     assert_no_stub_calls "$tmp_dir"
+}
+
+help_copilot_mentions_tmux() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_stub_bins "$tmp_dir"
+
+    run_cmd "$tmp_dir/host/sandbox" copilot --help
+    assert_exit_code 0 "$RUN_CODE"
+    assert_stdout_contains "Usage: sandbox copilot" "$RUN_STDOUT"
+    assert_stdout_contains "tmux" "$RUN_STDOUT"
+    assert_stdout_contains "Arguments after \"--\" are passed to copilot" "$RUN_STDOUT"
+
+    assert_no_files_created "$tmp_dir"
+    assert_no_stub_calls "$tmp_dir"
+}
+
+package_json_lists_copilot_install_and_verify() {
+    local package_json="$REPO_ROOT/package.json"
+
+    if ! grep -Fq '"@github/copilot": "latest"' "$package_json"; then
+        echo "Expected @github/copilot dependency in package.json" >&2
+        return 1
+    fi
+    if ! grep -Fq '@github/copilot' "$package_json"; then
+        echo "Expected @github/copilot in install-global" >&2
+        return 1
+    fi
+    if ! grep -Fq 'copilot --version' "$package_json"; then
+        echo "Expected copilot --version in verify" >&2
+        return 1
+    fi
 }
 
 help_subcommand() {
@@ -460,7 +493,7 @@ up_creates_agent_home_dirs() {
 
     run_cmd "$tmp_dir/host/sandbox" up --mount-root "$root" --workdir "$root"
     assert_exit_code 0 "$RUN_CODE"
-    if [[ ! -d "$tmp_dir/.agent-home/.claude" || ! -d "$tmp_dir/.agent-home/.codex" || ! -d "$tmp_dir/.agent-home/commandhistory" ]]; then
+    if [[ ! -d "$tmp_dir/.agent-home/.claude" || ! -d "$tmp_dir/.agent-home/.copilot" || ! -d "$tmp_dir/.agent-home/.codex" || ! -d "$tmp_dir/.agent-home/commandhistory" ]]; then
         echo "agent-home directories should be created" >&2
         return 1
     fi
@@ -757,7 +790,7 @@ build_only() {
         echo ".env should be created for build" >&2
         return 1
     fi
-    if [[ ! -d "$tmp_dir/.agent-home/.claude" ]]; then
+    if [[ ! -d "$tmp_dir/.agent-home/.claude" || ! -d "$tmp_dir/.agent-home/.copilot" ]]; then
         echo ".agent-home should be created for build" >&2
         return 1
     fi
@@ -1390,10 +1423,96 @@ codex_errors_when_tmux_missing() {
     assert_stderr_contains "tmux command not found" "$RUN_STDERR"
 }
 
+copilot_outer_uses_tmux_and_session_name() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+
+    export STUB_TMUX_HAS_SESSION=0
+
+    local base_dir="$tmp_dir/My.Project:One"
+    mkdir -p "$base_dir"
+
+    CALLER_PWD="$base_dir" run_cmd "$tmp_dir/host/sandbox" copilot
+    assert_exit_code 0 "$RUN_CODE"
+
+    local expected_session="My_Project_One-copilot-sandbox"
+    assert_log_contains "$tmux_log" "has-session"
+    assert_log_contains "$tmux_log" "new-session"
+    assert_log_contains "$tmux_log" "=$expected_session"
+    assert_log_contains "$tmux_log" "SANDBOX_COPILOT_NO_TMUX=1"
+    assert_log_contains "$tmux_log" "$tmp_dir/host/sandbox"
+    assert_log_not_contains "$COMPOSE_LOG_FILE" "CMD="
+    assert_no_files_created "$tmp_dir"
+}
+
+copilot_inner_runs_copilot_and_returns_to_zsh() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    local workdir="$root/subdir"
+    setup_env_for_up "$tmp_dir" "$root" "$workdir"
+
+    SANDBOX_COPILOT_NO_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$workdir"
+    assert_exit_code 0 "$RUN_CODE"
+    assert_log_contains "$log_file" "CMD=docker compose up -d --build"
+    assert_log_contains "$log_file" "CMD=docker compose exec -w /srv/mount/project/subdir"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_contains "$log_file" "exec\\ /bin/zsh"
+}
+
+copilot_help_flag_after_double_dash_is_passed_to_copilot() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    SANDBOX_COPILOT_NO_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --help
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ "$RUN_STDOUT" == *"Usage: sandbox"* ]]; then
+        echo "Sandbox help was printed unexpectedly" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "--help"
+    assert_log_contains "$log_file" "copilot"
+}
+
+copilot_errors_when_tmux_missing() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    local no_tmux_path
+    no_tmux_path="$(mktemp -d)"
+    ln -sf "$(command -v dirname)" "$no_tmux_path/dirname"
+    ln -sf "$(command -v basename)" "$no_tmux_path/basename"
+    ln -sf "$(command -v realpath)" "$no_tmux_path/realpath"
+    ln -sf "$(command -v readlink)" "$no_tmux_path/readlink"
+
+    run_cmd env -i HOME="$tmp_dir" PATH="$no_tmux_path" /bin/bash "$tmp_dir/host/sandbox" copilot
+    if [[ "$RUN_CODE" -eq 0 ]]; then
+        echo "Expected tmux error for copilot" >&2
+        return 1
+    fi
+    assert_stderr_contains "tmux command not found" "$RUN_STDERR"
+}
+
 run_test "help_top_level" help_top_level
 run_test "help_subcommand" help_subcommand
 run_test "help_any_position" help_any_position
+run_test "help_copilot_mentions_tmux" help_copilot_mentions_tmux
 run_test "help_codex_mentions_auto_bootstrap_and_conflicts" help_codex_mentions_auto_bootstrap_and_conflicts
+run_test "package_json_lists_copilot_install_and_verify" package_json_lists_copilot_install_and_verify
 run_test "help_has_no_side_effects" help_has_no_side_effects
 run_test "name_one_line_stdout" name_one_line_stdout
 run_test "docker_cmd_missing_errors" docker_cmd_missing_errors
@@ -1436,3 +1555,7 @@ run_test "codex_inner_git_rev_parse_failure_warns_and_runs_bootstrap" codex_inne
 run_test "codex_rejects_conflicting_args_before_compose" codex_rejects_conflicting_args_before_compose
 run_test "codex_help_flag_after_double_dash_is_passed_to_codex" codex_help_flag_after_double_dash_is_passed_to_codex
 run_test "codex_errors_when_tmux_missing" codex_errors_when_tmux_missing
+run_test "copilot_outer_uses_tmux_and_session_name" copilot_outer_uses_tmux_and_session_name
+run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copilot_and_returns_to_zsh
+run_test "copilot_help_flag_after_double_dash_is_passed_to_copilot" copilot_help_flag_after_double_dash_is_passed_to_copilot
+run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -1483,7 +1483,7 @@ copilot_help_flag_after_double_dash_is_passed_to_copilot() {
     local root="$tmp_dir/project"
     setup_env_for_up "$tmp_dir" "$root" "$root"
 
-    SANDBOX_COPILOT_NO_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --help
+    SANDBOX_COPILOT_NO_TMUX=1 SANDBOX_COPILOT_FORCE_TMUX=1 run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --help
     assert_exit_code 0 "$RUN_CODE"
     if [[ "$RUN_STDOUT" == *"Usage: sandbox"* ]]; then
         echo "Sandbox help was printed unexpectedly" >&2
@@ -1527,7 +1527,7 @@ copilot_noninteractive_bypasses_tmux() {
     local stderr_file
     stderr_file="$(mktemp)"
     set +e
-    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" -s 2>"$stderr_file")"
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" --allow-all-tools 2>"$stderr_file")"
     RUN_CODE=$?
     RUN_STDERR="$(cat "$stderr_file")"
     set -e
@@ -1543,7 +1543,7 @@ copilot_noninteractive_bypasses_tmux() {
     assert_log_contains "$log_file" "copilot"
     assert_log_contains "$log_file" "-p"
     assert_log_contains "$log_file" "Say\\ hello"
-    assert_log_contains "$log_file" "-s"
+    assert_log_contains "$log_file" "--allow-all-tools"
     assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
@@ -1564,7 +1564,7 @@ copilot_noninteractive_preserves_exit_status() {
     local stderr_file
     stderr_file="$(mktemp)"
     set +e
-    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" -s 2>"$stderr_file")"
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" --allow-all-tools 2>"$stderr_file")"
     RUN_CODE=$?
     RUN_STDERR="$(cat "$stderr_file")"
     set -e
@@ -1582,7 +1582,42 @@ copilot_noninteractive_preserves_exit_status() {
     assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
-copilot_redirected_stdout_bypasses_tmux() {
+copilot_programmatic_requires_approval_override() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    local stderr_file
+    stderr_file="$(mktemp)"
+    set +e
+    RUN_STDOUT="$(printf 'hello\n' | "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- -p "Say hello" 2>"$stderr_file")"
+    RUN_CODE=$?
+    RUN_STDERR="$(cat "$stderr_file")"
+    set -e
+    rm -f "$stderr_file"
+
+    if [[ "$RUN_CODE" -eq 0 ]]; then
+        echo "Expected programmatic copilot without approval override to fail" >&2
+        return 1
+    fi
+    assert_stderr_contains "requires --allow-all-tools" "$RUN_STDERR"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux to be used when approval override is missing" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_not_contains "$log_file" "CMD="
+}
+
+copilot_redirected_stdout_errors_for_interactive_mode() {
     local tmp_dir
     tmp_dir="$(make_fake_sandbox_root)"
     setup_compose_stubs "$tmp_dir"
@@ -1596,16 +1631,25 @@ copilot_redirected_stdout_bypasses_tmux() {
     setup_env_for_up "$tmp_dir" "$root" "$root"
 
     local out_file="$tmp_dir/copilot.out"
-    "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" >"$out_file"
+    local stderr_file="$tmp_dir/copilot.err"
+    set +e
+    "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" >"$out_file" 2>"$stderr_file"
+    RUN_CODE=$?
+    RUN_STDOUT="$(cat "$out_file" 2>/dev/null || true)"
+    RUN_STDERR="$(cat "$stderr_file" 2>/dev/null || true)"
+    set -e
 
+    if [[ "$RUN_CODE" -eq 0 ]]; then
+        echo "Expected interactive copilot with redirected stdout to fail" >&2
+        return 1
+    fi
+    assert_stderr_contains "requires a TTY on stdin and stdout" "$RUN_STDERR"
     if [[ -s "$tmux_log" ]]; then
-        echo "Did not expect tmux to be used when stdout is redirected" >&2
+        echo "Did not expect tmux to be used when interactive stdout is redirected" >&2
         cat "$tmux_log" >&2
         return 1
     fi
-    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
-    assert_log_contains "$log_file" "copilot"
-    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+    assert_log_not_contains "$log_file" "CMD="
 }
 
 run_test "help_top_level" help_top_level
@@ -1660,6 +1704,7 @@ run_test "copilot_outer_uses_tmux_and_session_name" copilot_outer_uses_tmux_and_
 run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copilot_and_returns_to_zsh
 run_test "copilot_help_flag_after_double_dash_is_passed_to_copilot" copilot_help_flag_after_double_dash_is_passed_to_copilot
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
+run_test "copilot_programmatic_requires_approval_override" copilot_programmatic_requires_approval_override
 run_test "copilot_noninteractive_bypasses_tmux" copilot_noninteractive_bypasses_tmux
-run_test "copilot_redirected_stdout_bypasses_tmux" copilot_redirected_stdout_bypasses_tmux
+run_test "copilot_redirected_stdout_errors_for_interactive_mode" copilot_redirected_stdout_errors_for_interactive_mode
 run_test "copilot_noninteractive_preserves_exit_status" copilot_noninteractive_preserves_exit_status

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -177,8 +177,8 @@ compute_expected_copilot_session_name() {
 run_in_pseudo_tty() {
     local command_string="$1"
 
-    if script -q -c "exit 0" /dev/null >/dev/null 2>&1; then
-        script -q -c "$command_string" /dev/null >/dev/null
+    if script -q -e -c "exit 0" /dev/null >/dev/null 2>&1; then
+        script -q -e -c "$command_string" /dev/null >/dev/null
         return $?
     fi
 
@@ -1607,6 +1607,32 @@ copilot_init_uses_direct_exec() {
     assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
+copilot_acp_uses_direct_exec() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- --acp
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux for copilot --acp" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_contains "$log_file" "--acp"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
 copilot_errors_when_tmux_missing() {
     local tmp_dir
     tmp_dir="$(make_fake_sandbox_root)"
@@ -1907,6 +1933,7 @@ run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copi
 run_test "copilot_help_flag_after_double_dash_uses_direct_exec" copilot_help_flag_after_double_dash_uses_direct_exec
 run_test "copilot_version_flag_uses_direct_exec" copilot_version_flag_uses_direct_exec
 run_test "copilot_init_uses_direct_exec" copilot_init_uses_direct_exec
+run_test "copilot_acp_uses_direct_exec" copilot_acp_uses_direct_exec
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
 run_test "copilot_programmatic_requires_approval_override" copilot_programmatic_requires_approval_override
 run_test "copilot_programmatic_accepts_allow_all_aliases" copilot_programmatic_accepts_allow_all_aliases

--- a/tests/sandbox_cli.test.sh
+++ b/tests/sandbox_cli.test.sh
@@ -165,6 +165,26 @@ compute_expected_compose_name() {
     compute_compose_project_name "$abs_root" "$abs_workdir"
 }
 
+compute_expected_copilot_session_name() {
+    local tmp_dir="$1"
+    local caller_pwd="$2"
+    # shellcheck source=/dev/null
+    source "$tmp_dir/host/sandbox"
+    CALLER_PWD="$caller_pwd"
+    compute_copilot_session_name
+}
+
+run_in_pseudo_tty() {
+    local command_string="$1"
+
+    if script -q -c "exit 0" /dev/null >/dev/null 2>&1; then
+        script -q -c "$command_string" /dev/null >/dev/null
+        return $?
+    fi
+
+    script -q /dev/null /bin/bash -lc "$command_string" >/dev/null
+}
+
 assert_log_contains() {
     local log_file="$1"
     local expected="$2"
@@ -1441,7 +1461,8 @@ copilot_outer_uses_tmux_and_session_name() {
     run_cmd env CALLER_PWD="$base_dir" SANDBOX_COPILOT_FORCE_TMUX=1 "$tmp_dir/host/sandbox" copilot
     assert_exit_code 0 "$RUN_CODE"
 
-    local expected_session="My_Project_One-copilot-sandbox"
+    local expected_session
+    expected_session="$(compute_expected_copilot_session_name "$tmp_dir" "$base_dir")"
     assert_log_contains "$tmux_log" "has-session"
     assert_log_contains "$tmux_log" "new-session"
     assert_log_contains "$tmux_log" "=$expected_session"
@@ -1449,6 +1470,38 @@ copilot_outer_uses_tmux_and_session_name() {
     assert_log_contains "$tmux_log" "$tmp_dir/host/sandbox"
     assert_log_not_contains "$COMPOSE_LOG_FILE" "CMD="
     assert_no_files_created "$tmp_dir"
+}
+
+copilot_session_name_disambiguates_same_basename_paths() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+
+    export STUB_TMUX_HAS_SESSION=0
+
+    local path_a="$tmp_dir/worktrees/app"
+    local path_b="$tmp_dir/other/app"
+    mkdir -p "$path_a" "$path_b"
+
+    run_cmd env CALLER_PWD="$path_a" SANDBOX_COPILOT_FORCE_TMUX=1 "$tmp_dir/host/sandbox" copilot
+    assert_exit_code 0 "$RUN_CODE"
+    local expected_a
+    expected_a="$(compute_expected_copilot_session_name "$tmp_dir" "$path_a")"
+    assert_log_contains "$tmux_log" "=$expected_a"
+
+    : > "$tmux_log"
+    run_cmd env CALLER_PWD="$path_b" SANDBOX_COPILOT_FORCE_TMUX=1 "$tmp_dir/host/sandbox" copilot
+    assert_exit_code 0 "$RUN_CODE"
+    local expected_b
+    expected_b="$(compute_expected_copilot_session_name "$tmp_dir" "$path_b")"
+    assert_log_contains "$tmux_log" "=$expected_b"
+
+    if [[ "$expected_a" == "$expected_b" ]]; then
+        echo "Expected distinct session names for different CALLER_PWD values" >&2
+        return 1
+    fi
 }
 
 copilot_inner_runs_copilot_and_returns_to_zsh() {
@@ -1525,6 +1578,32 @@ copilot_version_flag_uses_direct_exec() {
     assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
     assert_log_contains "$log_file" "--version"
     assert_log_contains "$log_file" "copilot"
+    assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
+}
+
+copilot_init_uses_direct_exec() {
+    local tmp_dir
+    tmp_dir="$(make_fake_sandbox_root)"
+    setup_compose_stubs "$tmp_dir"
+    setup_tmux_stubs "$tmp_dir"
+    local tmux_log="$tmp_dir/tmux.log"
+    local log_file="$COMPOSE_LOG_FILE"
+    export STUB_DOCKER_INFO_EXIT=0
+    export STUB_DOCKER_COMPOSE_VERSION="Docker Compose version v2.20.0"
+
+    local root="$tmp_dir/project"
+    setup_env_for_up "$tmp_dir" "$root" "$root"
+
+    run_cmd "$tmp_dir/host/sandbox" copilot --mount-root "$root" --workdir "$root" -- init
+    assert_exit_code 0 "$RUN_CODE"
+    if [[ -s "$tmux_log" ]]; then
+        echo "Did not expect tmux for copilot init" >&2
+        cat "$tmux_log" >&2
+        return 1
+    fi
+    assert_log_contains "$log_file" "CMD=docker compose exec -T -w /srv/mount/project"
+    assert_log_contains "$log_file" "copilot"
+    assert_log_contains "$log_file" "init"
     assert_log_not_contains "$log_file" "exec\\ /bin/zsh"
 }
 
@@ -1755,7 +1834,7 @@ copilot_redirected_stdout_errors_for_interactive_mode() {
     printf -v command_string '%q copilot --mount-root %q --workdir %q >%q 2>%q' \
         "$tmp_dir/host/sandbox" "$root" "$root" "$out_file" "$stderr_file"
     set +e
-    script -q /dev/null /bin/bash -lc "$command_string" >/dev/null
+    run_in_pseudo_tty "$command_string"
     RUN_CODE=$?
     RUN_STDOUT="$(cat "$out_file" 2>/dev/null || true)"
     RUN_STDERR="$(cat "$stderr_file" 2>/dev/null || true)"
@@ -1823,9 +1902,11 @@ run_test "codex_rejects_conflicting_args_before_compose" codex_rejects_conflicti
 run_test "codex_help_flag_after_double_dash_is_passed_to_codex" codex_help_flag_after_double_dash_is_passed_to_codex
 run_test "codex_errors_when_tmux_missing" codex_errors_when_tmux_missing
 run_test "copilot_outer_uses_tmux_and_session_name" copilot_outer_uses_tmux_and_session_name
+run_test "copilot_session_name_disambiguates_same_basename_paths" copilot_session_name_disambiguates_same_basename_paths
 run_test "copilot_inner_runs_copilot_and_returns_to_zsh" copilot_inner_runs_copilot_and_returns_to_zsh
 run_test "copilot_help_flag_after_double_dash_uses_direct_exec" copilot_help_flag_after_double_dash_uses_direct_exec
 run_test "copilot_version_flag_uses_direct_exec" copilot_version_flag_uses_direct_exec
+run_test "copilot_init_uses_direct_exec" copilot_init_uses_direct_exec
 run_test "copilot_errors_when_tmux_missing" copilot_errors_when_tmux_missing
 run_test "copilot_programmatic_requires_approval_override" copilot_programmatic_requires_approval_override
 run_test "copilot_programmatic_accepts_allow_all_aliases" copilot_programmatic_accepts_allow_all_aliases


### PR DESCRIPTION
## Summary
- GitHub Copilot CLI を sandbox の共有 npm ツール群へ追加
- `.agent-home/.copilot` を `/home/node/.copilot` に mount する永続化を追加
- `sandbox copilot [options] -- [copilot args...]` を追加し、tmux 経由でコンテナ内 `copilot` を起動できるようにした
- help、verify、Bash テスト、spec-dock ドキュメントを Copilot 対応に更新

## Related
- Closes #10

## Changes
- `package.json`
  - `@github/copilot` を追加
  - `install-global` と `verify` を更新
- `Dockerfile`
  - `/home/node/.copilot` を事前作成
- `docker-compose.yml`
  - `.agent-home/.copilot:/home/node/.copilot` mount を追加
- `host/sandbox`
  - `sandbox copilot` サブコマンドを追加
  - `--` 以降の引数 pass-through を実装
  - help 文面を更新
- `tests/sandbox_cli.test.sh`
  - Copilot 用の help / tmux / compose exec / pass-through / tmux missing テストを追加
- `.spec-dock/current/*`
  - 要件・設計・計画を実装内容に合わせて更新

## Verification
- `bash tests/sandbox_cli.test.sh`
- `./host/sandbox up --mount-root . --workdir .`
- `./host/sandbox tools update --mount-root . --workdir .`
- `docker exec sandbox-box-87a7e19a9e8f /bin/zsh -lc 'cd /opt/sandbox && npm run verify'`
- `docker exec sandbox-box-87a7e19a9e8f /bin/zsh -lc 'command -v codex; codex --version; command -v copilot; copilot --version'`

## Notes
- `./host/sandbox build --mount-root . --workdir .` 単体はローカル sandbox 制約により Docker buildx activity 書き込みで失敗したが、`./host/sandbox up ...` で実ビルドと起動は正常に完了した
